### PR TITLE
Fix contract path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
 
 ## Adresses des Smart Contracts (Testnet Aeneid)
 
-Les adresses exactes des smart contracts déployés sur le testnet Aeneid se trouvent dans le fichier `/home/ubuntu/web3-project/implementation/smart-contracts/deployment-info.json`.
+Les adresses exactes des smart contracts déployés sur le testnet Aeneid se trouvent dans le fichier `smart-contracts/deployment-info.json`.
 
 ## Notes Importantes
 

--- a/docs/recapitulatif_projet_mintyshirt.md
+++ b/docs/recapitulatif_projet_mintyshirt.md
@@ -127,7 +127,7 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
 
 ## Adresses des Smart Contracts (Testnet Aeneid)
 
-Les adresses exactes des smart contracts déployés sur le testnet Aeneid se trouvent dans le fichier `/home/ubuntu/web3-project/implementation/smart-contracts/deployment-info.json`.
+Les adresses exactes des smart contracts déployés sur le testnet Aeneid se trouvent dans le fichier `smart-contracts/deployment-info.json`.
 
 ## Notes Importantes
 


### PR DESCRIPTION
## Summary
- update the README to use a relative path for deployment info
- fix same path in `recapitulatif_projet_mintyshirt.md`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a7c95a088329a49e6f40108bd426