### PR TITLE
Fix misprint in deploy guide

### DIFF
--- a/docs/guide_deploiement_securise.md
+++ b/docs/guide_deploiement_securise.md
@@ -40,7 +40,7 @@ Cette commande peut prendre quelques minutes pour s'exécuter.
 2. Ajoutez les lignes suivantes dans ce fichier :
 
 ```
-# Configuration pour le testnet Story Protocol Aenid
+# Configuration pour le testnet Story Protocol Aeneid
 STORY_PROTOCOL_TESTNET_URL=https://aeneid.storyrpc.io
 PRIVATE_KEY=VOTRE_CLE_PRIVEE_ICI
 ETHERSCAN_API_KEY=ABCDEFGHIJKLMNOPQRSTUVWXYZ123456


### PR DESCRIPTION
## Summary
- fix typo in Story Protocol testnet name

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a7c10a748329813cd64daac1a276