### PR TITLE
Fix frontend CI/CD workflow

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd frontend
-        npm ci
+        npm install
         
     - name: Build
       run: |


### PR DESCRIPTION
## Summary
- run `npm install` in GitHub Actions instead of `npm ci`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68442d28627883298cbf7f9c3a25504f