### PR TITLE
Fix Netlify build by adding autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^3.1.0",
+    "autoprefixer": "^10.4.21",
     "vite": "^4.2.1",
     "jest": "^29.5.0",
     "chai": "^5.2.0",


### PR DESCRIPTION
## Summary
- add missing `autoprefixer` PostCSS plugin to dev dependencies

## Testing
- `npm test` *(fails: Unexpected token 'export' from chai)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8ed9dfc83299ed53d6f4e3ee8f6