### PR TITLE
Add basic registration/login

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -12,12 +12,15 @@ app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
 
 app.register_blueprint(user_bp, url_prefix='/api')
 
-# uncomment if you need to use database
-# app.config['SQLALCHEMY_DATABASE_URI'] = f"mysql+pymysql://{os.getenv('DB_USERNAME', 'root')}:{os.getenv('DB_PASSWORD', 'password')}@{os.getenv('DB_HOST', 'localhost')}:{os.getenv('DB_PORT', '3306')}/{os.getenv('DB_NAME', 'mydb')}"
-# app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-# db.init_app(app)
-# with app.app_context():
-#     db.create_all()
+# Basic SQLite setup. Override SQLALCHEMY_DATABASE_URI to use another database.
+app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(
+    'DATABASE_URL',
+    'sqlite:///' + os.path.join(os.path.dirname(__file__), 'mintyshirt.db')
+)
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+db.init_app(app)
+with app.app_context():
+    db.create_all()
 
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -11,6 +11,15 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
 
     def __repr__(self):
         return f"<User {self.username}>"
+
+    def set_password(self, password: str) -> None:
+        from werkzeug.security import generate_password_hash
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        from werkzeug.security import check_password_hash
+        return check_password_hash(self.password_hash, password)

--- a/backend/src/routes/user.py
+++ b/backend/src/routes/user.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
+from werkzeug.exceptions import BadRequest, Unauthorized
+from src.models.user import db, User
 
 user_bp = Blueprint('user', __name__)
 
@@ -6,3 +8,35 @@ user_bp = Blueprint('user', __name__)
 def list_users():
     """Placeholder route returning a simple message."""
     return jsonify({'message': 'List of users coming soon'})
+
+
+@user_bp.route('/register', methods=['POST'])
+def register():
+    data = request.get_json() or {}
+    username = data.get('username')
+    email = data.get('email')
+    password = data.get('password')
+    if not username or not email or not password:
+        raise BadRequest('Missing required fields')
+    if User.query.filter_by(username=username).first() is not None:
+        raise BadRequest('Username already exists')
+    if User.query.filter_by(email=email).first() is not None:
+        raise BadRequest('Email already exists')
+    user = User(username=username, email=email)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    return jsonify({'id': user.id, 'username': user.username, 'email': user.email})
+
+
+@user_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json() or {}
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        raise BadRequest('Missing credentials')
+    user = User.query.filter_by(username=username).first()
+    if user is None or not user.check_password(password):
+        raise Unauthorized('Invalid credentials')
+    return jsonify({'id': user.id, 'username': user.username, 'email': user.email})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,18 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage';
+import RegisterPage from './components/RegisterPage';
+import LoginPage from './components/LoginPage';
 
 function App() {
-  return <HomePage />;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/login" element={<LoginPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -56,12 +56,12 @@ function Navbar() {
             <span className="text-xl">🛒</span>
             <span className="absolute -top-1 -right-2 bg-purple-600 text-white text-xs rounded-full px-1">0</span>
           </button>
-          <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded">
-            Connect Wallet
-          </button>
-          <button className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap">
+          <a href="/login" className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded">
+            Se connecter
+          </a>
+          <a href="/register" className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap">
             S'inscrire
-          </button>
+          </a>
         </div>
       </div>
     </nav>

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      setMessage('Connexion réussie');
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setMessage(data.message || 'Erreur');
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2 text-white">Connexion</h1>
+      <form onSubmit={submit} className="space-y-2 max-w-sm">
+        <input className="border p-2 w-full" placeholder="Nom d'utilisateur" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="Mot de passe" value={password} onChange={e => setPassword(e.target.value)} />
+        <button className="bg-purple-600 text-white px-4 py-2" type="submit">Se connecter</button>
+      </form>
+      {message && <p className="mt-2 text-white">{message}</p>}
+    </div>
+  );
+}

--- a/src/components/RegisterPage.tsx
+++ b/src/components/RegisterPage.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+export default function RegisterPage() {
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, email, password })
+    });
+    if (res.ok) {
+      setMessage('Inscription réussie');
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setMessage(data.message || 'Erreur');
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2 text-white">Inscription</h1>
+      <form onSubmit={submit} className="space-y-2 max-w-sm">
+        <input className="border p-2 w-full" placeholder="Nom d'utilisateur" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="Mot de passe" value={password} onChange={e => setPassword(e.target.value)} />
+        <button className="bg-purple-600 text-white px-4 py-2" type="submit">S'inscrire</button>
+      </form>
+      {message && <p className="mt-2 text-white">{message}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- enable SQLite database setup in backend
- add user password hash helper methods
- implement `/register` and `/login` endpoints
- add simple registration and login forms
- hook up routing for home, register and login
- update navbar links

## Testing
- `npm run build`
- `npm test` *(fails: Jest unable to parse chai module)*

------
https://chatgpt.com/codex/tasks/task_e_6846e1b097bc832986e378ccf238ba07