### PR TITLE
Add shop, cart and i18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "axios": "^1.3.5",
         "ethers": "^5.7.2",
         "express": "^4.18.2",
+        "i18next": "^25.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.5.2",
         "react-icons": "^4.12.0",
         "react-router-dom": "^6.10.0",
         "tailwindcss": "^3.3.1"
@@ -517,6 +519,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4992,6 +5003,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -5030,6 +5050,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
+      "integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -7462,6 +7513,32 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.2.tgz",
+      "integrity": "sha512-ePODyXgmZQAOYTbZXQn5rRsSBu3Gszo69jxW6aKmlSgxKAI1fOhDwSu6bT4EKHciWPKQ7v7lPrjeiadR6Gi+1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
@@ -8701,6 +8778,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "axios": "^1.3.5",
     "ethers": "^5.7.2",
     "express": "^4.18.2",
+    "i18next": "^25.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^15.5.2",
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.10.0",
     "tailwindcss": "^3.3.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,11 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage';
 import RegisterPage from './components/RegisterPage';
 import LoginPage from './components/LoginPage';
+import ShopPage from './components/ShopPage';
+import ProductPage from './components/ProductPage';
+import CartPage from './components/CartPage';
+import DashboardPage from './components/DashboardPage';
+import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   return (
@@ -10,6 +15,17 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/shop" element={<ShopPage />} />
+        <Route path="/product/:id" element={<ProductPage />} />
+        <Route path="/cart" element={<CartPage />} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute role="creator">
+              <DashboardPage />
+            </ProtectedRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/CartPage.tsx
+++ b/src/components/CartPage.tsx
@@ -1,0 +1,27 @@
+import { useCart } from '../contexts/CartContext';
+
+export default function CartPage() {
+  const { items, remove, clear } = useCart();
+  const total = items.reduce((sum, i) => sum + i.product.price * i.qty, 0);
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl font-bold mb-4">Panier</h1>
+      {items.length === 0 && <p>Votre panier est vide.</p>}
+      {items.map(i => (
+        <div key={i.product.id} className="flex justify-between border-b py-2">
+          <span>{i.product.name} x{i.qty}</span>
+          <span>{i.product.price * i.qty} ETH</span>
+          <button onClick={() => remove(i.product.id)} className="ml-2">X</button>
+        </div>
+      ))}
+      {items.length > 0 && (
+        <div className="mt-4 space-y-2">
+          <p>Total: {total.toFixed(2)} ETH</p>
+          <button className="bg-purple-600 text-white px-4 py-2 rounded">Commander</button>
+          <button onClick={clear} className="ml-2 underline">Vider</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import { ethers } from 'ethers';
+
+export default function ConnectWallet() {
+  const [address, setAddress] = useState<string>('');
+
+  async function connect() {
+    if (!(window as any).ethereum) return;
+    const provider = new ethers.providers.Web3Provider((window as any).ethereum);
+    await provider.send('eth_requestAccounts', []);
+    const signer = provider.getSigner();
+    const addr = await signer.getAddress();
+    setAddress(addr);
+  }
+
+  return (
+    <button onClick={connect} className="bg-purple-500 text-white px-3 py-1 rounded">
+      {address ? `${address.slice(0,6)}...${address.slice(-4)}` : 'Connect Wallet'}
+    </button>
+  );
+}

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -1,0 +1,26 @@
+import { useAuth } from '../contexts/AuthContext';
+import { products } from '../data/products';
+
+export default function DashboardPage() {
+  const { user } = useAuth();
+  const myProducts = user?.type === 'creator' ? products : [];
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      {user?.type === 'creator' ? (
+        <div>
+          <h2 className="font-semibold mb-2">Vos produits</h2>
+          <ul className="list-disc pl-5">
+            {myProducts.map(p => (
+              <li key={p.id}>{p.name}</li>
+            ))}
+          </ul>
+          <button className="mt-4 bg-purple-600 text-white px-4 py-2 rounded">Créer un nouveau design</button>
+        </div>
+      ) : (
+        <p>Rien à afficher.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { FaYoutube, FaTiktok, FaInstagram, FaTwitter, FaFacebook } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
+import ConnectWallet from './ConnectWallet';
+import { useAuth } from '../contexts/AuthContext';
+import { useCart } from '../contexts/CartContext';
 
 function Navbar() {
+  const { user } = useAuth();
+  const { items } = useCart();
   const categories = [
     'Créateurs de contenu',
     'Musiciens',
@@ -52,16 +59,22 @@ function Navbar() {
             placeholder="Rechercher…"
             className="border rounded px-2 py-1 text-black"
           />
-          <button className="relative">
+          <Link to="/cart" className="relative">
             <span className="text-xl">🛒</span>
-            <span className="absolute -top-1 -right-2 bg-purple-600 text-white text-xs rounded-full px-1">0</span>
-          </button>
-          <a href="/login" className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded">
-            Se connecter
-          </a>
-          <a href="/register" className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap">
-            S'inscrire
-          </a>
+            <span className="absolute -top-1 -right-2 bg-purple-600 text-white text-xs rounded-full px-1">{items.length}</span>
+          </Link>
+          <Link to={user ? '/dashboard' : '/register'} className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap">
+            Créer un produit
+          </Link>
+          {user ? (
+            <span>{user.email}</span>
+          ) : (
+            <>
+              <a href="/login" className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded">Se connecter</a>
+              <a href="/register" className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap">S'inscrire</a>
+            </>
+          )}
+          <ConnectWallet />
         </div>
       </div>
     </nav>
@@ -69,23 +82,24 @@ function Navbar() {
 }
 
 function Hero() {
+  const { t } = useTranslation();
   return (
     <section
       className="text-center text-white py-24 bg-gradient-to-r from-purple-800 via-purple-600 to-fuchsia-600"
     >
-      <h1 className="text-4xl md:text-6xl font-bold mb-4">Success is shared</h1>
+      <h1 className="text-4xl md:text-6xl font-bold mb-4">{t('welcome')}</h1>
       <div className="space-x-4">
         <a
           href="/shop"
           className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-6 py-2 rounded font-semibold"
         >
-          Explorer les produits
+          {t('explore')}
         </a>
         <a
           href="/register"
           className="bg-white text-purple-700 hover:bg-purple-100 transition-colors px-6 py-2 rounded font-semibold"
         >
-          vendre un produit
+          {t('sell')}
         </a>
       </div>
     </section>
@@ -144,6 +158,7 @@ function HowItWorks() {
 }
 
 function Footer() {
+  const { i18n } = useTranslation();
   return (
     <footer className="bg-[#2C1D59] text-white py-12 mt-12">
       <div className="max-w-7xl mx-auto px-4 space-y-8">
@@ -172,6 +187,12 @@ function Footer() {
             S'inscrire
           </button>
         </form>
+        <div className="flex justify-center">
+          <select onChange={e => i18n.changeLanguage(e.target.value)} className="text-black p-1 rounded">
+            <option value="fr">FR</option>
+            <option value="en">EN</option>
+          </select>
+        </div>
         <p className="text-center text-sm">MintyShirt est propulsé par Story Protocol</p>
       </div>
     </footer>

--- a/src/components/ProductPage.tsx
+++ b/src/components/ProductPage.tsx
@@ -1,0 +1,30 @@
+import { useParams } from 'react-router-dom';
+import { products } from '../data/products';
+import { useCart } from '../contexts/CartContext';
+
+export default function ProductPage() {
+  const { id } = useParams();
+  const product = products.find(p => p.id === Number(id));
+  const { add } = useCart();
+
+  if (!product) return <p className="p-4 text-white">Produit introuvable</p>;
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl font-bold mb-4">{product.name}</h1>
+      <div className="md:flex space-x-4">
+        <div className="h-64 w-64 bg-gray-200 mb-4" />
+        <div>
+          <p className="mb-2">Créateur : {product.creator}</p>
+          <p className="mb-2">Prix : {product.price} ETH</p>
+          <div className="mb-2 space-x-2">
+            {['S','M','L'].map(s => (
+              <button key={s} className="border px-2 py-1">{s}</button>
+            ))}
+          </div>
+          <button onClick={() => add(product)} className="bg-purple-600 text-white px-4 py-2 rounded">Ajouter au panier</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function ProtectedRoute({ children, role }: { children: JSX.Element; role?: 'creator' | 'client' }) {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/login" replace />;
+  if (role && user.type !== role) return <Navigate to="/" replace />;
+  return children;
+}

--- a/src/components/RegisterPage.tsx
+++ b/src/components/RegisterPage.tsx
@@ -1,36 +1,49 @@
 import { useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function RegisterPage() {
+  const [type, setType] = useState<'creator' | 'client'>('client');
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [pseudo, setPseudo] = useState('');
+  const [description, setDescription] = useState('');
   const [message, setMessage] = useState('');
+  const { login } = useAuth();
 
-  async function submit(e: React.FormEvent) {
+  function submit(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch('/api/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, email, password })
-    });
-    if (res.ok) {
-      setMessage('Inscription réussie');
-    } else {
-      const data = await res.json().catch(() => ({}));
-      setMessage(data.message || 'Erreur');
+    if (password !== confirm) {
+      setMessage('Les mots de passe ne correspondent pas');
+      return;
     }
+    login({ type, email });
+    setMessage('Compte créé');
   }
 
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold mb-2 text-white">Inscription</h1>
+    <div className="p-4 text-white">
+      <h1 className="text-xl font-bold mb-2">Inscription</h1>
       <form onSubmit={submit} className="space-y-2 max-w-sm">
-        <input className="border p-2 w-full" placeholder="Nom d'utilisateur" value={username} onChange={e => setUsername(e.target.value)} />
-        <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
-        <input className="border p-2 w-full" type="password" placeholder="Mot de passe" value={password} onChange={e => setPassword(e.target.value)} />
+        <select value={type} onChange={e => setType(e.target.value as any)} className="border p-2 w-full text-black">
+          <option value="client">Client</option>
+          <option value="creator">Créateur</option>
+        </select>
+        <input className="border p-2 w-full text-black" placeholder="Nom d'utilisateur" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="border p-2 w-full text-black" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="border p-2 w-full text-black" type="password" placeholder="Mot de passe" value={password} onChange={e => setPassword(e.target.value)} />
+        <input className="border p-2 w-full text-black" type="password" placeholder="Confirmez le mot de passe" value={confirm} onChange={e => setConfirm(e.target.value)} />
+        {type === 'creator' && (
+          <div className="space-y-2">
+            <input className="border p-2 w-full text-black" placeholder="Pseudo" value={pseudo} onChange={e => setPseudo(e.target.value)} />
+            <textarea className="border p-2 w-full text-black" placeholder="Description courte" value={description} onChange={e => setDescription(e.target.value)} />
+            <input type="file" className="border p-2 w-full text-black" />
+          </div>
+        )}
         <button className="bg-purple-600 text-white px-4 py-2" type="submit">S'inscrire</button>
       </form>
-      {message && <p className="mt-2 text-white">{message}</p>}
+      {message && <p className="mt-2">{message}</p>}
     </div>
   );
 }

--- a/src/components/ShopPage.tsx
+++ b/src/components/ShopPage.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { products, categories } from '../data/products';
+import { useCart } from '../contexts/CartContext';
+import { Link } from 'react-router-dom';
+
+export default function ShopPage() {
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState('');
+  const [sort, setSort] = useState('');
+  const { add } = useCart();
+
+  const filtered = products
+    .filter(p => !category || p.name.includes(category))
+    .filter(p => p.name.toLowerCase().includes(search.toLowerCase()))
+    .sort((a, b) => {
+      if (sort === 'asc') return a.price - b.price;
+      if (sort === 'desc') return b.price - a.price;
+      return 0;
+    });
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl font-bold mb-4">Shop</h1>
+      <div className="flex space-x-2 mb-4">
+        <input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Recherche"
+          className="p-2 rounded text-black"
+        />
+        <select
+          value={category}
+          onChange={e => setCategory(e.target.value)}
+          className="p-2 rounded text-black"
+        >
+          <option value="">Catégorie</option>
+          {categories.map(c => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+        <select
+          value={sort}
+          onChange={e => setSort(e.target.value)}
+          className="p-2 rounded text-black"
+        >
+          <option value="">Tri</option>
+          <option value="asc">Prix croissant</option>
+          <option value="desc">Prix décroissant</option>
+        </select>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        {filtered.map(p => (
+          <div key={p.id} className="bg-white/10 p-4 rounded">
+            <div className="h-40 bg-gray-200 mb-2" />
+            <h3 className="font-semibold">{p.name}</h3>
+            <p className="text-sm">{p.creator}</p>
+            <p className="font-bold">{p.price} ETH</p>
+            <div className="flex space-x-2 mt-2">
+              <Link to={`/product/${p.id}`} className="bg-purple-600 text-white px-2 py-1 rounded">Voir</Link>
+              <button onClick={() => add(p)} className="bg-purple-500 text-white px-2 py-1 rounded">Ajouter</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+
+export interface User {
+  type: 'creator' | 'client';
+  email: string;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  login: (user: User) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('authUser');
+    if (stored) {
+      try { setUser(JSON.parse(stored)); } catch {}
+    }
+  }, []);
+
+  const login = (u: User) => {
+    setUser(u);
+    localStorage.setItem('authUser', JSON.stringify(u));
+  };
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem('authUser');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface Product {
+  id: number;
+  name: string;
+  creator: string;
+  price: number;
+  image?: string;
+}
+
+export interface CartItem {
+  product: Product;
+  qty: number;
+}
+
+interface CartContextValue {
+  items: CartItem[];
+  add: (p: Product) => void;
+  remove: (id: number) => void;
+  clear: () => void;
+}
+
+const CartContext = createContext<CartContextValue>({
+  items: [],
+  add: () => {},
+  remove: () => {},
+  clear: () => {},
+});
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const add = (p: Product) => {
+    setItems((curr) => {
+      const existing = curr.find((c) => c.product.id === p.id);
+      if (existing) {
+        return curr.map((c) =>
+          c.product.id === p.id ? { ...c, qty: c.qty + 1 } : c
+        );
+      }
+      return [...curr, { product: p, qty: 1 }];
+    });
+  };
+
+  const remove = (id: number) => {
+    setItems((curr) => curr.filter((c) => c.product.id !== id));
+  };
+
+  const clear = () => setItems([]);
+
+  return (
+    <CartContext.Provider value={{ items, add, remove, clear }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  return useContext(CartContext);
+}

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,0 +1,9 @@
+import { Product } from '../contexts/CartContext';
+
+export const products: Product[] = [
+  { id: 1, name: 'Samurai Tee', creator: 'Akira', price: 0.05, image: '' , },
+  { id: 2, name: 'Pixel Cat Hoodie', creator: 'Mia', price: 0.08, image: '' , },
+  { id: 3, name: 'VR World Shirt', creator: 'Noah', price: 0.06, image: '' , },
+];
+
+export const categories = ['Mangas', 'Jeux vidéo', 'Art visuel'];

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,28 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  fr: {
+    translation: {
+      welcome: 'Success is shared',
+      explore: 'Explorer les produits',
+      sell: 'Vendre un produit',
+    },
+  },
+  en: {
+    translation: {
+      welcome: 'Success is shared',
+      explore: 'Browse products',
+      sell: 'Sell a product',
+    },
+  },
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'fr',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,23 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
+import './i18n';
+import { I18nextProvider } from 'react-i18next';
+import i18n from './i18n';
+import { AuthProvider } from './contexts/AuthContext';
+import { CartProvider } from './contexts/CartContext';
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
   createRoot(rootElement).render(
     <React.StrictMode>
-      <App />
+      <I18nextProvider i18n={i18n}>
+        <AuthProvider>
+          <CartProvider>
+            <App />
+          </CartProvider>
+        </AuthProvider>
+      </I18nextProvider>
     </React.StrictMode>
   );
 }


### PR DESCRIPTION
## Summary
- build auth and cart contexts
- create pages for shop, product, cart and dashboard
- add wallet connection component
- hook up protected routes
- integrate basic i18n with language selector

## Testing
- `npm test --silent` *(fails: Jest unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6846e98343008329ad492981ad63c9eb