### PR TITLE
Add Tomo service with env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example environment configuration for MintyShirt
+
+# Frontend
+VITE_API_URL=http://localhost:5000/api
+VITE_CONTRACT_REGISTRY=
+VITE_CONTRACT_LICENSE=
+VITE_CONTRACT_REVENUE=
+VITE_CHAIN_ID=
+
+# Backend
+FLASK_ENV=development
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///backend/src/mintyshirt.db
+IPFS_API_KEY=
+CONTRACT_ADDRESSES=
+TOMO_API_KEY=
+TOMO_API_URL=

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
    - `DATABASE_URL` : URL de la base de données
    - `IPFS_API_KEY` : Clé API pour IPFS (si applicable)
    - `CONTRACT_ADDRESSES` : Adresses des smart contracts
+   - `TOMO_API_KEY` : Clé API pour l'intégration Tomo.inc
+   - `TOMO_API_URL` : URL de l'API Tomo.inc
 
 ## Adresses des Smart Contracts (Testnet Aeneid)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 SQLAlchemy
+requests

--- a/backend/src/services/tomo_service.py
+++ b/backend/src/services/tomo_service.py
@@ -1,0 +1,34 @@
+import os
+from typing import Any
+
+import requests
+
+
+def verify_token_ownership(
+    wallet_address: str,
+    contract_address: str,
+    chain_id: int,
+    min_amount: int = 1,
+) -> bool:
+    """Verify token ownership via the external Tomo.inc API."""
+    api_key = os.getenv("TOMO_API_KEY")
+    base_url = os.getenv("TOMO_API_URL")
+    if not api_key or not base_url:
+        raise RuntimeError("TOMO_API_KEY and TOMO_API_URL must be configured")
+
+    url = f"{base_url.rstrip('/')}/verify"
+    payload = {
+        "wallet_address": wallet_address,
+        "contract_address": contract_address,
+        "chain_id": chain_id,
+        "min_amount": min_amount,
+        "api_key": api_key,
+    }
+
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+        data: Any = response.json()
+        return bool(data.get("has_tokens"))
+    except requests.RequestException:
+        return False


### PR DESCRIPTION
## Summary
- add example configuration in `.env.example`
- document Tomo API variables in README
- add `requests` dependency
- implement `verify_token_ownership` service for Tomo API

## Testing
- `python -m py_compile backend/src/services/tomo_service.py`
- `find backend/src -name '*.py' -print | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6847f09eb46c8329a30252064d0c97de