### PR TITLE
Adjust header layout and login page link

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -19,8 +19,31 @@ function Navbar() {
 
   return (
     <nav className="sticky top-0 bg-[#2C1D59] text-white shadow z-10">
-      <div className="max-w-7xl mx-auto flex items-center justify-between p-4">
-        <div className="flex items-center space-x-6">
+      <div className="max-w-7xl mx-auto p-4 space-y-2">
+        <div className="flex items-center justify-end space-x-4">
+          <input
+            type="text"
+            placeholder="Rechercher…"
+            className="border rounded px-2 py-1 text-black"
+          />
+          <button className="relative">
+            <span className="text-xl">🛒</span>
+            <span className="absolute -top-1 -right-2 bg-purple-600 text-white text-xs rounded-full px-1">0</span>
+          </button>
+          <a
+            href="/login"
+            className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded whitespace-nowrap"
+          >
+            Connecter le portefeuille
+          </a>
+          <a
+            href="/login"
+            className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap"
+          >
+            Connexion
+          </a>
+        </div>
+        <div className="flex items-center space-x-6 pt-2">
           <span className="font-bold text-xl whitespace-nowrap">MintyShirt</span>
           <div className="hidden md:flex space-x-6 items-center">
             <a href="#" className="hover:text-purple-300 whitespace-nowrap">Accueil</a>
@@ -30,11 +53,7 @@ function Navbar() {
               <button className="hover:text-purple-300 whitespace-nowrap">Catégories</button>
               <div className="absolute left-0 mt-2 hidden group-hover:block bg-white text-gray-900 shadow rounded p-2 space-y-1">
                 {categories.map((cat) => (
-                  <a
-                    key={cat}
-                    href="#"
-                    className="block px-2 py-1 hover:bg-purple-100 whitespace-nowrap"
-                  >
+                  <a key={cat} href="#" className="block px-2 py-1 hover:bg-purple-100 whitespace-nowrap">
                     {cat}
                   </a>
                 ))}
@@ -46,22 +65,6 @@ function Navbar() {
             <a href="#" className="hover:text-purple-300 whitespace-nowrap">Stats</a>
           </div>
         </div>
-        <div className="flex items-center space-x-4">
-          <input
-            type="text"
-            placeholder="Rechercher…"
-            className="border rounded px-2 py-1 text-black"
-          />
-          <button className="relative">
-            <span className="text-xl">🛒</span>
-            <span className="absolute -top-1 -right-2 bg-purple-600 text-white text-xs rounded-full px-1">0</span>
-          </button>
-          <a href="/login" className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded">
-            Se connecter
-          </a>
-          <a href="/register" className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap">
-            S'inscrire
-          </a>
         </div>
       </div>
     </nav>

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -24,10 +24,29 @@ export default function LoginPage() {
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2 text-white">Connexion</h1>
       <form onSubmit={submit} className="space-y-2 max-w-sm">
-        <input className="border p-2 w-full" placeholder="Nom d'utilisateur" value={username} onChange={e => setUsername(e.target.value)} />
-        <input className="border p-2 w-full" type="password" placeholder="Mot de passe" value={password} onChange={e => setPassword(e.target.value)} />
-        <button className="bg-purple-600 text-white px-4 py-2" type="submit">Se connecter</button>
+        <input
+          className="border p-2 w-full"
+          placeholder="Nom d'utilisateur"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          type="password"
+          placeholder="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-purple-600 text-white px-4 py-2" type="submit">
+          Se connecter
+        </button>
       </form>
+      <p className="mt-2 text-white">
+        Pas encore de compte ?{' '}
+        <a href="/register" className="text-purple-300 hover:underline">
+          Créer un compte
+        </a>
+      </p>
       {message && <p className="mt-2 text-white">{message}</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- reposition MintyShirt logo and nav slightly below the search/cart/buttons block
- rename buttons to "Connecter le portefeuille" and "Connexion"
- keep consistent vertical spacing
- add sign-up link on the login page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fe9d68e483298061c7a767c41be6