### PR TITLE
Add creators page with slug-based routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
         <Route path="/shop" element={<ShopPage />} />
         <Route path="/shop/:category" element={<AccessoryCategoryPage />} />
         <Route path="/creators" element={<CreatorsPage />} />
-        <Route path="/creators/:name" element={<CreatorPage />} />
+        <Route path="/creators/:slug" element={<CreatorPage />} />
         <Route path="/categories" element={<CategoriesPage />} />
         <Route path="/royalty-tokens" element={<RoyaltyTokensPage />} />
         <Route path="/token-swap" element={<TokenSwapPage />} />

--- a/src/components/CreatorPage.tsx
+++ b/src/components/CreatorPage.tsx
@@ -3,13 +3,14 @@ import { useParams } from 'react-router-dom';
 import Navbar from './Navbar';
 
 export default function CreatorPage() {
-  const { name } = useParams();
+  const { slug } = useParams<{ slug: string }>();
+
   return (
     <div className="font-sans">
       <Navbar />
-      <div className="max-w-7xl mx-auto mt-6 px-4 text-white">
-        <h1 className="text-3xl font-bold mb-4 capitalize">{name}</h1>
-        <p>Page du créateur {name}.</p>
+      <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-2">
+        <h1 className="text-3xl font-bold capitalize">{slug}</h1>
+        <p>Détails du créateur {slug} à venir.</p>
       </div>
     </div>
   );

--- a/src/components/CreatorsPage.tsx
+++ b/src/components/CreatorsPage.tsx
@@ -2,22 +2,35 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Navbar from './Navbar';
 
+interface Creator {
+  name: string;
+  slug: string;
+}
+
 export default function CreatorsPage() {
-  const creators = ['alice', 'bob', 'charlie'];
+  const creators: Creator[] = [
+    { name: 'Alice', slug: 'alice' },
+    { name: 'Bob', slug: 'bob' },
+    { name: 'Charlie', slug: 'charlie' },
+  ];
+
   return (
     <div className="font-sans">
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white">
         <h1 className="text-3xl font-bold mb-4">Créateurs</h1>
-        <ul className="space-y-2">
-          {creators.map((c) => (
-            <li key={c}>
-              <Link to={`/creators/${c}`} className="text-purple-300 hover:underline capitalize">
-                {c}
-              </Link>
-            </li>
+        <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+          {creators.map((creator) => (
+            <Link
+              key={creator.slug}
+              to={`/creators/${creator.slug}`}
+              className="bg-white/10 backdrop-blur border border-purple-800 rounded shadow p-4 flex flex-col items-center text-center hover:bg-white/20 transition-colors"
+            >
+              <div className="bg-gray-200 h-32 w-full mb-2" />
+              <h3 className="font-semibold capitalize">{creator.name}</h3>
+            </Link>
           ))}
-        </ul>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add card grid for creators list and link to slug route
- read creator slug on creator page and show placeholder
- update routes to use `/creators/:slug`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc4454f008329b7ce09466fbc9862