### PR TITLE
Add category slugs and dynamic pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
         <Route path="/creators" element={<CreatorsPage />} />
         <Route path="/creators/:slug" element={<CreatorPage />} />
         <Route path="/categories" element={<CategoriesPage />} />
+        <Route path="/categories/:slug" element={<CategoriesPage />} />
         <Route path="/royalty-tokens" element={<RoyaltyTokensPage />} />
         <Route path="/token-swap" element={<TokenSwapPage />} />
         <Route path="/design-hub" element={<DesignHubPage />} />

--- a/src/components/CategoriesPage.tsx
+++ b/src/components/CategoriesPage.tsx
@@ -1,32 +1,41 @@
 import React from 'react';
+import { Link, useParams } from 'react-router-dom';
 import Navbar from './Navbar';
+import { categories } from '../lib/categories';
 
 export default function CategoriesPage() {
-  const categories = [
-    'Créateurs de contenu',
-    'Musiciens',
-    'Mangas',
-    'BD & Animés',
-    'Jeux vidéo',
-    'Séries',
-    'Films',
-    'Art visuel',
-    'Clubs sportifs',
-    'Crypto',
-    'Collections de NFTs',
-    'Marques & Entreprises',
-  ];
+  const { slug } = useParams<{ slug?: string }>();
+
+  if (!slug) {
+    return (
+      <div className="font-sans">
+        <Navbar />
+        <div className="max-w-7xl mx-auto mt-6 px-4 text-white">
+          <h1 className="text-3xl font-bold mb-4">Catégories</h1>
+          <ul className="space-y-2">
+            {categories.map((cat) => (
+              <li key={cat.slug}>
+                <Link to={`/categories/${cat.slug}`} className="hover:underline">
+                  {cat.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+
+  const category = categories.find((c) => c.slug === slug);
 
   return (
     <div className="font-sans">
       <Navbar />
-      <div className="max-w-7xl mx-auto mt-6 px-4 text-white">
-        <h1 className="text-3xl font-bold mb-4">Catégories</h1>
-        <ul className="space-y-2">
-          {categories.map((cat) => (
-            <li key={cat}>{cat}</li>
-          ))}
-        </ul>
+      <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-2">
+        <h1 className="text-3xl font-bold capitalize">
+          {category ? category.name : slug}
+        </h1>
+        <p>Contenu pour la catégorie {category ? category.name : slug} à venir.</p>
       </div>
     </div>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,29 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { categories } from '../lib/categories';
 
 export default function Navbar() {
-  const categories = [
-    'Créateurs de contenu',
-    'Musiciens',
-    'Mangas',
-    'BD & Animés',
-    'Jeux vidéo',
-    'Séries',
-    'Films',
-    'Art visuel',
-    'Clubs sportifs',
-    'Crypto',
-    'Collections de NFTs',
-    'Marques & Entreprises',
-  ];
-
-  const slugify = (str: string) =>
-    str
-      .toLowerCase()
-      .normalize('NFD')
-      .replace(/\p{Diacritic}/gu, '')
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '');
 
   const [categoriesOpen, setCategoriesOpen] = React.useState(false);
   const closeTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -89,11 +68,11 @@ export default function Navbar() {
               >
                 {categories.map((cat) => (
                   <Link
-                    key={cat}
-                    to={`/categories/${slugify(cat)}`}
+                    key={cat.slug}
+                    to={`/categories/${cat.slug}`}
                     className="block px-2 py-1 hover:bg-purple-100 whitespace-nowrap"
                   >
-                    {cat}
+                    {cat.name}
                   </Link>
                 ))}
               </div>

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,21 @@
+export interface Category {
+  name: string;
+  slug: string;
+}
+
+export const categories: Category[] = [
+  { name: 'Créateurs de contenu', slug: 'createurs-de-contenu' },
+  { name: 'Musiciens', slug: 'musiciens' },
+  { name: 'Jeux vidéo', slug: 'jeux-video' },
+  { name: 'Manga', slug: 'manga' },
+  { name: 'BD & Animés', slug: 'bd-animes' },
+  { name: 'Crypto', slug: 'crypto' },
+  { name: 'NFT', slug: 'nft' },
+  { name: 'Clubs sportifs', slug: 'clubs-sportifs' },
+  { name: 'Séries', slug: 'series' },
+  { name: 'Films', slug: 'films' },
+  { name: 'Art visuel', slug: 'art-visuel' },
+  { name: 'Mode', slug: 'mode' },
+  { name: 'Marques & entreprises', slug: 'marques-entreprises' },
+  { name: 'Autres', slug: 'autres' },
+];


### PR DESCRIPTION
## Summary
- centralize category list with slugs
- link categories in navbar to `/categories/{slug}`
- show placeholder category page when slug is provided
- hook up dynamic route for `/categories/:slug`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc54a9ff88329a5c78a4436707aa6