### PR TITLE
Add TokenSwap marketplace pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import CreatorPage from './components/CreatorPage';
 import CategoriesPage from './components/CategoriesPage';
 import RoyaltyTokensPage from './components/RoyaltyTokensPage';
 import TokenSwapPage from './components/TokenSwapPage';
+import TokenDetailPage from './components/TokenDetailPage';
 import DesignHubPage from './components/DesignHubPage';
 import IpAssetPage from './components/IpAssetPage';
 import StatsPage from './components/StatsPage';
@@ -28,7 +29,8 @@ function App() {
         <Route path="/categories" element={<CategoriesPage />} />
         <Route path="/categories/:slug" element={<CategoriesPage />} />
         <Route path="/royalty-tokens" element={<RoyaltyTokensPage />} />
-        <Route path="/token-swap" element={<TokenSwapPage />} />
+        <Route path="/tokenswap" element={<TokenSwapPage />} />
+        <Route path="/tokenswap/:id" element={<TokenDetailPage />} />
         <Route path="/design-hub" element={<DesignHubPage />} />
         <Route path="/design-hub/:id" element={<IpAssetPage />} />
         <Route path="/wallet-connect" element={<WalletConnectPage />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -78,7 +78,7 @@ export default function Navbar() {
               </div>
             </div>
             <Link to="/royalty-tokens" className="hover:text-purple-300 whitespace-nowrap">Royalty Tokens</Link>
-            <Link to="/token-swap" className="hover:text-purple-300 whitespace-nowrap">TokenSwap</Link>
+            <Link to="/tokenswap" className="hover:text-purple-300 whitespace-nowrap">TokenSwap</Link>
             <Link to="/design-hub" className="hover:text-purple-300 whitespace-nowrap">DesignHub</Link>
             <Link to="/stats" className="hover:text-purple-300 whitespace-nowrap">Stats</Link>
           </div>

--- a/src/components/TokenDetailPage.tsx
+++ b/src/components/TokenDetailPage.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { tokens } from '../lib/tokens';
+
+export default function TokenDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const token = tokens.find(t => t.id === id);
+
+  return (
+    <div className="font-sans">
+      <Navbar />
+      <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-4">
+        {token ? (
+          <>
+            <div className="flex items-center space-x-4">
+              <div className="text-4xl">{token.logo}</div>
+              <h1 className="text-3xl font-bold">{token.name}</h1>
+            </div>
+            <div>
+              Créateur:
+              <Link to={`/creators/${token.creatorSlug}`} className="text-purple-300 hover:underline ml-1">
+                {token.creator}
+              </Link>
+            </div>
+            <div>Catégorie: {token.category}</div>
+            <div>
+              Page IP associée:
+              <Link to={`/design-hub/${token.ipAssetId}`} className="text-purple-300 hover:underline ml-1">
+                Voir l'actif IP
+              </Link>
+            </div>
+            <p>{token.description}</p>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="bg-white/10 backdrop-blur border border-purple-800 rounded p-4 space-y-1">
+                <div>Dernier prix échangé: {token.lastPrice} ETH</div>
+                <div>Volume 24h: {token.volume24h} ETH</div>
+                <div>Nombre de détenteurs: {token.holders}</div>
+                <div>% des revenus redistribués: {token.revenueShare}%</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur border border-purple-800 rounded p-4">
+                <div className="font-semibold mb-2">Avantages associés</div>
+                <ul className="list-disc list-inside space-y-1">
+                  {token.perks.map(p => (
+                    <li key={p}>{p}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            <div className="space-x-2">
+              <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded">
+                Acheter maintenant
+              </button>
+              <Link to={`/creators/${token.creatorSlug}`} className="bg-blue-600 hover:bg-blue-700 transition-colors text-white px-4 py-2 rounded">
+                Voir sur la boutique du créateur
+              </Link>
+            </div>
+          </>
+        ) : (
+          <h1 className="text-3xl font-bold">Token introuvable</h1>
+        )}
+
+        <p className="text-sm mt-8">
+          Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier, mais représentent un droit à redevance lié à l’usage commercial d’une œuvre ou d’une marque, déterminé par le créateur lui-même. MintyShirt ne garantit aucun rendement. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/TokenSwapPage.tsx
+++ b/src/components/TokenSwapPage.tsx
@@ -1,14 +1,116 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import { tokens, SwapToken } from '../lib/tokens';
+import { categories } from '../lib/categories';
+import { FaArrowUp, FaArrowDown, FaMinus } from 'react-icons/fa';
 
 export default function TokenSwapPage() {
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState('');
+  const [sort, setSort] = useState('top-sales');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const navigate = useNavigate();
+
+  const filtered = tokens
+    .filter(t => t.name.toLowerCase().includes(search.toLowerCase()) ||
+      t.creator.toLowerCase().includes(search.toLowerCase()))
+    .filter(t => !category || t.category === category)
+    .filter(t => (!minPrice || t.lastPrice >= parseFloat(minPrice)) &&
+      (!maxPrice || t.lastPrice <= parseFloat(maxPrice)));
+
+  const sorted = [...filtered].sort((a, b) => {
+    switch (sort) {
+      case 'top-price':
+        return b.lastPrice - a.lastPrice;
+      case 'recent':
+        return new Date(b.listedAt).getTime() - new Date(a.listedAt).getTime();
+      case 'popular':
+        return b.holders - a.holders;
+      default:
+        return b.volume24h - a.volume24h;
+    }
+  });
+
+  function changeIcon(val: number) {
+    if (val > 0) return <span className="text-green-500 inline-flex items-center"><FaArrowUp className="mr-1" />{val.toFixed(1)}%</span>;
+    if (val < 0) return <span className="text-red-500 inline-flex items-center"><FaArrowDown className="mr-1" />{val.toFixed(1)}%</span>;
+    return <span className="inline-flex items-center"><FaMinus className="mr-1" />0%</span>;
+  }
+
   return (
     <div className="font-sans">
       <Navbar />
-      <div className="max-w-7xl mx-auto mt-6 px-4 text-white">
-        <h1 className="text-3xl font-bold mb-4">Token Swap</h1>
-        <p>Échangez vos tokens ici.</p>
+      <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-4">
+        <h1 className="text-3xl font-bold">TokenSwap - Marché secondaire des Royalty Tokens</h1>
+
+        <div className="bg-white/10 backdrop-blur p-4 rounded border border-purple-800 space-y-2">
+          <input
+            type="text"
+            placeholder="Rechercher un token ou un créateur"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="border p-2 text-black w-full md:w-1/2"
+          />
+          <div className="flex flex-wrap items-end space-x-2">
+            <select value={category} onChange={e => setCategory(e.target.value)} className="border p-2 text-black">
+              <option value="">Catégories</option>
+              {categories.map(c => (
+                <option key={c.slug} value={c.name}>{c.name}</option>
+              ))}
+            </select>
+            <select value={sort} onChange={e => setSort(e.target.value)} className="border p-2 text-black">
+              <option value="top-sales">Top ventes</option>
+              <option value="top-price">Top prix</option>
+              <option value="recent">Récents</option>
+              <option value="popular">Populaires</option>
+            </select>
+            <input type="number" placeholder="Min" value={minPrice} onChange={e => setMinPrice(e.target.value)} className="border p-2 text-black w-24" />
+            <input type="number" placeholder="Max" value={maxPrice} onChange={e => setMaxPrice(e.target.value)} className="border p-2 text-black w-24" />
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm border border-purple-800">
+            <thead className="bg-purple-800/50">
+              <tr>
+                <th className="px-2 py-1">Logo</th>
+                <th className="px-2 py-1 text-left">Nom</th>
+                <th className="px-2 py-1 text-left">Créateur</th>
+                <th className="px-2 py-1 text-right">Dernier prix</th>
+                <th className="px-2 py-1 text-right">24h</th>
+                <th className="px-2 py-1 text-right">Volume 24h</th>
+                <th className="px-2 py-1 text-right">En vente</th>
+                <th className="px-2 py-1" />
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map(t => (
+                <tr key={t.id} className="hover:bg-white/10 cursor-pointer" onClick={() => navigate(`/tokenswap/${t.id}`)}>
+                  <td className="px-2 py-1 text-center">{t.logo}</td>
+                  <td className="px-2 py-1">{t.name}</td>
+                  <td className="px-2 py-1">{t.creator}</td>
+                  <td className="px-2 py-1 text-right">{t.lastPrice} ETH</td>
+                  <td className="px-2 py-1 text-right">{changeIcon(t.change24h)}</td>
+                  <td className="px-2 py-1 text-right">{t.volume24h} ETH</td>
+                  <td className="px-2 py-1 text-right">{t.quantity}</td>
+                  <td className="px-2 py-1">
+                    <button
+                      className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-2 py-1 rounded"
+                      onClick={e => { e.stopPropagation(); }}
+                    >Acheter</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="text-sm mt-4">
+          Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier, mais représentent un droit à redevance lié à l’usage commercial d’une œuvre ou d’une marque, déterminé par le créateur lui-même. MintyShirt ne garantit aucun rendement. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.
+        </p>
       </div>
       <Footer />
     </div>

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,0 +1,75 @@
+export interface SwapToken {
+  id: string;
+  logo: string;
+  name: string;
+  creator: string;
+  creatorSlug: string;
+  category: string;
+  lastPrice: number; // ETH
+  change24h: number; // percent
+  volume24h: number; // ETH
+  quantity: number;
+  description: string;
+  ipAssetId: string;
+  holders: number;
+  revenueShare: number; // percent
+  perks: string[];
+  listedAt: string; // ISO date
+}
+
+export const tokens: SwapToken[] = [
+  {
+    id: 'royalties_mx',
+    logo: '🔶',
+    name: 'Royalties_MX',
+    creator: 'MangaX',
+    creatorSlug: 'mangax',
+    category: 'Mangas',
+    lastPrice: 0.032,
+    change24h: 5.2,
+    volume24h: 12,
+    quantity: 14,
+    description: 'Token donnant droit à une part des revenus des produits MangaX.',
+    ipAssetId: '1',
+    holders: 78,
+    revenueShare: 25,
+    perks: ['Groupe privé', 'Lien d’affiliation', 'Réductions sur le merch'],
+    listedAt: '2023-10-01T00:00:00Z'
+  },
+  {
+    id: 'merchtoken_d',
+    logo: '🔷',
+    name: 'MerchToken_D',
+    creator: 'DJ Nova',
+    creatorSlug: 'dj-nova',
+    category: 'Musique',
+    lastPrice: 0.012,
+    change24h: -3.1,
+    volume24h: 4,
+    quantity: 6,
+    description: 'Accès à des remises exclusives sur le merch de DJ Nova.',
+    ipAssetId: '2',
+    holders: 42,
+    revenueShare: 15,
+    perks: ['Groupe privé', 'Réductions sur le merch'],
+    listedAt: '2023-10-03T00:00:00Z'
+  },
+  {
+    id: 'royalties_ri',
+    logo: '🔴',
+    name: 'Royalties_Ri',
+    creator: 'RickFan',
+    creatorSlug: 'rickfan',
+    category: 'Comics/fantastique',
+    lastPrice: 0.021,
+    change24h: 0,
+    volume24h: 8,
+    quantity: 10,
+    description: 'Partage des revenus des ventes de la série RickFan.',
+    ipAssetId: '3',
+    holders: 55,
+    revenueShare: 20,
+    perks: ['Groupe privé'],
+    listedAt: '2023-09-28T00:00:00Z'
+  }
+];


### PR DESCRIPTION
## Summary
- create mock token data for swap listings
- build TokenSwap page with search, filters, sortable table and legal note
- add Token detail page with creator links and perks
- add routes for `/tokenswap` and `/tokenswap/:id`
- update navbar link

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dde68e2908329ba28d23759860fb1