### PR TITLE
Add detailed stats links on creator cards

### DIFF
--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -191,6 +191,12 @@ export default function StatsPage() {
               >
                 Voir la page du créateur
               </Link>
+              <Link
+                to={`/stats/${creator.slug}`}
+                className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded inline-block mt-2"
+              >
+                Voir les statistiques détaillées
+              </Link>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add a new `Link` on each creator card in `StatsPage.tsx`
- link points to `/stats/{creator.slug}`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e93cf7a048329a9af15a49c20a61f