### PR TITLE
Add stat overview graphs with period selector

### DIFF
--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -98,6 +98,19 @@ export default function StatsPage() {
   const [category, setCategory] = useState('');
   const [sort, setSort] = useState('sales');
   const [country, setCountry] = useState('');
+  const [period, setPeriod] = useState('7d');
+
+  const periods = [
+    { label: 'Derniers 7 jours', value: '7d' },
+    { label: 'Dernier mois', value: '1m' },
+    { label: 'Cette année', value: '1y' },
+  ];
+
+  const statsByPeriod: Record<string, { merch: number; swap: number; creators: number }> = {
+    '7d': { merch: 12500, swap: 14, creators: 8 },
+    '1m': { merch: 48600, swap: 63, creators: 22 },
+    '1y': { merch: 572000, swap: 720, creators: 95 },
+  };
 
   const filtered = creators
     .filter((c) => (category ? c.category === category : true))
@@ -130,6 +143,47 @@ export default function StatsPage() {
             MintyShirt. Classement basé sur les ventes de produits, l’activité
             liée aux tokens, et l'engagement communautaire.
           </p>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {periods.map((p) => (
+              <button
+                key={p.value}
+                onClick={() => setPeriod(p.value)}
+                className={`px-3 py-1 rounded border ${period === p.value ? 'bg-purple-600' : 'bg-white/10'}`}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-2 text-center">
+              <div className="h-24 bg-purple-600/40 rounded flex items-center justify-center">
+                Graphique merch
+              </div>
+              <div className="font-semibold">
+                {statsByPeriod[period].merch.toLocaleString('fr-FR')} € de merch
+              </div>
+            </div>
+            <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-2 text-center">
+              <div className="h-24 bg-purple-600/40 rounded flex items-center justify-center">
+                Graphique tokens
+              </div>
+              <div className="font-semibold">
+                {statsByPeriod[period].swap} ETH échangés
+              </div>
+            </div>
+            <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-2 text-center">
+              <div className="h-24 bg-purple-600/40 rounded flex items-center justify-center">
+                Graphique créateurs
+              </div>
+              <div className="font-semibold">
+                {statsByPeriod[period].creators} créateurs actifs
+              </div>
+            </div>
+          </div>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- show an overview section on `StatsPage` with placeholder graphs for merch revenue, token swap volume and active creators
- allow choosing data over different periods using a simple selector

## Testing
- `npm test` *(fails: Hardhat artifacts missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e947caaac8329b69661faaf89dfc5