### PR TITLE
Refactor stats pages

### DIFF
--- a/src/components/CreatorStatsPage.tsx
+++ b/src/components/CreatorStatsPage.tsx
@@ -5,16 +5,18 @@ import Footer from './Footer';
 
 interface StatsEntry {
   date: string;
-  sales: number;
+  merchVolume: number;
+  itemsSold: number;
   tokenVolume: number;
+  tokenTx: number;
 }
 
 const sampleData: StatsEntry[] = [
-  { date: '2024-05-01', sales: 120, tokenVolume: 50 },
-  { date: '2024-05-02', sales: 80, tokenVolume: 30 },
-  { date: '2024-05-03', sales: 60, tokenVolume: 25 },
-  { date: '2024-05-04', sales: 100, tokenVolume: 45 },
-  { date: '2024-05-05', sales: 70, tokenVolume: 20 },
+  { date: '2024-05-01', merchVolume: 1200, itemsSold: 12, tokenVolume: 50, tokenTx: 5 },
+  { date: '2024-05-02', merchVolume: 800, itemsSold: 8, tokenVolume: 30, tokenTx: 3 },
+  { date: '2024-05-03', merchVolume: 600, itemsSold: 6, tokenVolume: 25, tokenTx: 2 },
+  { date: '2024-05-04', merchVolume: 1000, itemsSold: 10, tokenVolume: 45, tokenTx: 4 },
+  { date: '2024-05-05', merchVolume: 700, itemsSold: 7, tokenVolume: 20, tokenTx: 2 },
 ];
 
 const periods = [
@@ -22,7 +24,9 @@ const periods = [
   { label: '7j', value: '7d' },
   { label: '30j', value: '30d' },
   { label: '90j', value: '90d' },
-  { label: 'Tout', value: 'all' },
+  { label: 'Année', value: '1y' },
+  { label: 'Toutes périodes', value: 'all' },
+  { label: 'Période personnalisée', value: 'custom' },
 ];
 
 export default function CreatorStatsPage() {
@@ -30,15 +34,17 @@ export default function CreatorStatsPage() {
   const [period, setPeriod] = useState('7d');
 
   const current = sampleData; // would be filtered by period in a real app
-  const totalSales = current.reduce((sum, d) => sum + d.sales, 0);
-  const totalVolume = current.reduce((sum, d) => sum + d.tokenVolume, 0);
+  const merchVolume = current.reduce((sum, d) => sum + d.merchVolume, 0);
+  const itemsSold = current.reduce((sum, d) => sum + d.itemsSold, 0);
+  const tokenVolume = current.reduce((sum, d) => sum + d.tokenVolume, 0);
+  const tokenTx = current.reduce((sum, d) => sum + d.tokenTx, 0);
 
   return (
     <div className="font-sans">
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-6">
         <div>
-          <h1 className="text-3xl font-bold mb-1">Stats de {creatorHandle}</h1>
+          <h1 className="text-3xl font-bold mb-1">Statistiques détaillées de {creatorHandle}</h1>
           <p className="text-sm">Performances économiques du créateur.</p>
         </div>
 
@@ -60,8 +66,8 @@ export default function CreatorStatsPage() {
               Graphique ventes (exemple)
             </div>
             <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-1">
-              <div className="font-semibold">Ventes totales : {totalSales}</div>
-              <div className="font-semibold">Volume TokenSwap : {totalVolume} ETH</div>
+              <div className="font-semibold">Volume de ventes de merches : {merchVolume} €</div>
+              <div className="font-semibold">Nombre d'articles vendus : {itemsSold}</div>
             </div>
           </div>
           <div className="space-y-2">
@@ -69,8 +75,8 @@ export default function CreatorStatsPage() {
               Graphique tokens (exemple)
             </div>
             <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-1">
-              <div className="font-semibold">Transactions : {current.length}</div>
-              <div className="font-semibold">Période sélectionnée : {period}</div>
+              <div className="font-semibold">Volume des échanges : {tokenVolume} ETH</div>
+              <div className="font-semibold">Nombre de transactions : {tokenTx}</div>
             </div>
           </div>
         </div>

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -86,19 +86,6 @@ export default function StatsPage() {
   const [category, setCategory] = useState('');
   const [sort, setSort] = useState('sales');
   const [country, setCountry] = useState('');
-  const [period, setPeriod] = useState('7d');
-
-  const periods = [
-    { label: 'Derniers 7 jours', value: '7d' },
-    { label: 'Dernier mois', value: '1m' },
-    { label: 'Cette année', value: '1y' },
-  ];
-
-  const statsByPeriod: Record<string, { merch: number; swap: number; creators: number }> = {
-    '7d': { merch: 12500, swap: 14, creators: 8 },
-    '1m': { merch: 48600, swap: 63, creators: 22 },
-    '1y': { merch: 572000, swap: 720, creators: 95 },
-  };
 
   const filtered = creators
     .filter((c) => (category ? c.category === category : true))
@@ -133,46 +120,7 @@ export default function StatsPage() {
           </p>
         </div>
 
-        <div className="space-y-4">
-          <div className="flex flex-wrap items-center gap-2">
-            {periods.map((p) => (
-              <button
-                key={p.value}
-                onClick={() => setPeriod(p.value)}
-                className={`px-3 py-1 rounded border ${period === p.value ? 'bg-purple-600' : 'bg-white/10'}`}
-              >
-                {p.label}
-              </button>
-            ))}
-          </div>
 
-          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-            <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-2 text-center">
-              <div className="h-24 bg-purple-600/40 rounded flex items-center justify-center">
-                Graphique merch
-              </div>
-              <div className="font-semibold">
-                {statsByPeriod[period].merch.toLocaleString('fr-FR')} € de merch
-              </div>
-            </div>
-            <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-2 text-center">
-              <div className="h-24 bg-purple-600/40 rounded flex items-center justify-center">
-                Graphique tokens
-              </div>
-              <div className="font-semibold">
-                {statsByPeriod[period].swap} ETH échangés
-              </div>
-            </div>
-            <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-2 text-center">
-              <div className="h-24 bg-purple-600/40 rounded flex items-center justify-center">
-                Graphique créateurs
-              </div>
-              <div className="font-semibold">
-                {statsByPeriod[period].creators} créateurs actifs
-              </div>
-            </div>
-          </div>
-        </div>
 
         <div className="flex flex-wrap items-center gap-2">
           <select
@@ -228,16 +176,16 @@ export default function StatsPage() {
               <p>Revenus merch (30j) : {creator.merchRevenue.toLocaleString('fr-FR')} €</p>
               <p>Membres groupe privé : {creator.groupMembers}</p>
               <Link
-                to={`/creators/${creator.slug}`}
-                className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded inline-block mt-2"
-              >
-                Voir la page du créateur
-              </Link>
-              <Link
                 to={`/stats/${creator.slug}`}
                 className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded inline-block mt-2"
               >
                 Voir les statistiques détaillées
+              </Link>
+              <Link
+                to={`/creators/${creator.slug}`}
+                className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded inline-block mt-2"
+              >
+                Voir la page du créateur
               </Link>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- remove global stat graphs from `/stats`
- show two navigation buttons per creator card
- add detailed creator metrics

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea1bc033083298a778a97c6f5912e