### PR TITLE
Implement creator onboarding path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import IpAssetPage from './components/IpAssetPage';
 import StatsPage from './components/StatsPage';
 import CreatorStatsPage from './components/CreatorStatsPage';
 import WalletConnectPage from './components/WalletConnectPage';
+import BecomeCreatorPage from './components/BecomeCreatorPage';
+import UploadDesignPage from './components/UploadDesignPage';
 
 function App() {
   return (
@@ -35,6 +37,8 @@ function App() {
         <Route path="/design-hub" element={<DesignHubPage />} />
         <Route path="/design-hub/:id" element={<IpAssetPage />} />
         <Route path="/wallet-connect" element={<WalletConnectPage />} />
+        <Route path="/become-creator" element={<BecomeCreatorPage />} />
+        <Route path="/upload-design" element={<UploadDesignPage />} />
         <Route path="/stats" element={<StatsPage />} />
         <Route path="/stats/:creatorHandle" element={<CreatorStatsPage />} />
       </Routes>

--- a/src/components/BecomeCreatorPage.tsx
+++ b/src/components/BecomeCreatorPage.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { useWeb3 } from '../contexts/Web3Context';
+import { registerCreator } from '../services/registry';
+
+export default function BecomeCreatorPage() {
+  const { address, provider, connect } = useWeb3();
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [creatorId, setCreatorId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!provider) {
+      await connect();
+      if (!provider) return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const id = await registerCreator(provider!, name, url);
+      setCreatorId(id);
+    } catch (err: any) {
+      setError(err.message || 'Erreur');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="font-sans">
+      <Navbar />
+      <div className="max-w-md mx-auto mt-6 p-4 text-white space-y-4">
+        <h1 className="text-2xl font-bold">Devenir Créateur</h1>
+        {!address && (
+          <button
+            onClick={connect}
+            className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
+          >
+            Connecter Wallet
+          </button>
+        )}
+        {address && (
+          <form onSubmit={submit} className="space-y-2">
+            <input
+              className="w-full border p-2 text-black"
+              placeholder="Nom de créateur"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <input
+              className="w-full border p-2 text-black"
+              placeholder="URL du profil"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <button
+              type="submit"
+              className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
+              disabled={loading}
+            >
+              {loading ? 'Enregistrement...' : "S'enregistrer comme créateur"}
+            </button>
+          </form>
+        )}
+        {creatorId && (
+          <p className="text-green-500">Inscription réussie ! ID créateur : {creatorId}</p>
+        )}
+        {error && <p className="text-red-500">{error}</p>}
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -16,12 +16,12 @@ function Hero() {
         >
           Explorer les produits
         </Link>
-        <a
-          href="/register"
+        <Link
+          to="/become-creator"
           className="bg-white text-purple-700 hover:bg-purple-100 transition-colors px-6 py-2 rounded font-semibold"
         >
-          vendre un produit
-        </a>
+          Devenir créateur
+        </Link>
       </div>
     </section>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -77,6 +77,8 @@ export default function Navbar() {
             <Link to="/tokenswap" className="hover:text-purple-300 whitespace-nowrap">TokenSwap</Link>
             <Link to="/design-hub" className="hover:text-purple-300 whitespace-nowrap">DesignHub</Link>
             <Link to="/stats" className="hover:text-purple-300 whitespace-nowrap">Stats</Link>
+            <Link to="/become-creator" className="hover:text-purple-300 whitespace-nowrap">Devenir Créateur</Link>
+            <Link to="/upload-design" className="hover:text-purple-300 whitespace-nowrap">Téléverser un Design</Link>
           </div>
         </div>
       </div>

--- a/src/components/UploadDesignPage.tsx
+++ b/src/components/UploadDesignPage.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { useWeb3 } from '../contexts/Web3Context';
+import { getCreatorId, registerIPAsset } from '../services/registry';
+
+export default function UploadDesignPage() {
+  const { provider, connect, address } = useWeb3();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [ipfsHash, setIpfsHash] = useState('');
+  const [contentType, setContentType] = useState('image/png');
+  const [allowAI, setAllowAI] = useState(false);
+  const [ipId, setIpId] = useState<number | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!provider) {
+      await connect();
+      if (!provider) return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const creatorId = await getCreatorId(provider!);
+      const id = await registerIPAsset(
+        provider!,
+        creatorId,
+        name,
+        description,
+        ipfsHash,
+        contentType,
+        allowAI
+      );
+      setIpId(id);
+    } catch (err: any) {
+      setError(err.message || 'Erreur');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="font-sans">
+      <Navbar />
+      <div className="max-w-md mx-auto mt-6 p-4 text-white space-y-4">
+        <h1 className="text-2xl font-bold">Téléverser un Design</h1>
+        {!address && (
+          <button
+            onClick={connect}
+            className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
+          >
+            Connecter Wallet
+          </button>
+        )}
+        {address && (
+          <form onSubmit={submit} className="space-y-2">
+            <input
+              className="w-full border p-2 text-black"
+              placeholder="Nom du design"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <textarea
+              className="w-full border p-2 text-black"
+              placeholder="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+            <input
+              className="w-full border p-2 text-black"
+              placeholder="Hash IPFS ou URL"
+              value={ipfsHash}
+              onChange={(e) => setIpfsHash(e.target.value)}
+            />
+            <input
+              className="w-full border p-2 text-black"
+              placeholder="Type de contenu"
+              value={contentType}
+              onChange={(e) => setContentType(e.target.value)}
+            />
+            <label className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={allowAI}
+                onChange={(e) => setAllowAI(e.target.checked)}
+              />
+              <span>Autoriser l'entraînement IA</span>
+            </label>
+            <button
+              type="submit"
+              className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
+              disabled={loading}
+            >
+              {loading ? 'Enregistrement...' : 'Enregistrer le design'}
+            </button>
+          </form>
+        )}
+        {ipId !== null && (
+          <p className="text-green-500">Design enregistré avec l'ID : {ipId}</p>
+        )}
+        {error && <p className="text-red-500">{error}</p>}
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/lib/abis/mintyShirtRegistry.json
+++ b/src/lib/abis/mintyShirtRegistry.json
@@ -1,0 +1,36 @@
+[
+  {
+    "inputs": [
+      {"internalType": "address", "name": "creatorAddress", "type": "address"},
+      {"internalType": "string", "name": "name", "type": "string"},
+      {"internalType": "string", "name": "profileUri", "type": "string"}
+    ],
+    "name": "registerCreator",
+    "outputs": [{"internalType": "uint256", "name": "creatorId", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "creatorId", "type": "uint256"},
+      {"internalType": "string", "name": "name", "type": "string"},
+      {"internalType": "string", "name": "description", "type": "string"},
+      {"internalType": "string", "name": "ipfsHash", "type": "string"},
+      {"internalType": "string", "name": "contentType", "type": "string"},
+      {"internalType": "bool", "name": "allowAI", "type": "bool"}
+    ],
+    "name": "registerIPAsset",
+    "outputs": [{"internalType": "uint256", "name": "ipId", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "creatorAddress", "type": "address"}
+    ],
+    "name": "getCreatorIdByAddress",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,0 +1,55 @@
+import { ethers } from 'ethers';
+import registryAbi from '../lib/abis/mintyShirtRegistry.json';
+
+const REGISTRY_ADDRESS = (window as any).env?.VITE_CONTRACT_REGISTRY || import.meta.env.VITE_CONTRACT_REGISTRY || '';
+
+export async function registerCreator(
+  provider: ethers.providers.Web3Provider,
+  name: string,
+  profileUri: string
+): Promise<number> {
+  const signer = provider.getSigner();
+  const contract = new ethers.Contract(REGISTRY_ADDRESS, registryAbi, signer);
+  const addr = await signer.getAddress();
+  const tx = await contract.registerCreator(addr, name, profileUri);
+  await tx.wait();
+  const id: ethers.BigNumber = await contract.getCreatorIdByAddress(addr);
+  return id.toNumber();
+}
+
+export async function getCreatorId(
+  provider: ethers.providers.Web3Provider
+): Promise<number> {
+  const signer = provider.getSigner();
+  const addr = await signer.getAddress();
+  const contract = new ethers.Contract(REGISTRY_ADDRESS, registryAbi, provider);
+  const id: ethers.BigNumber = await contract.getCreatorIdByAddress(addr);
+  return id.toNumber();
+}
+
+export async function registerIPAsset(
+  provider: ethers.providers.Web3Provider,
+  creatorId: number,
+  name: string,
+  description: string,
+  ipfsHash: string,
+  contentType: string,
+  allowAI: boolean
+): Promise<number> {
+  const signer = provider.getSigner();
+  const contract = new ethers.Contract(REGISTRY_ADDRESS, registryAbi, signer);
+  const tx = await contract.registerIPAsset(
+    creatorId,
+    name,
+    description,
+    ipfsHash,
+    contentType,
+    allowAI
+  );
+  const receipt = await tx.wait();
+  const event = receipt.events?.find((e: any) => e.event === 'IPAssetRegistered');
+  if (event && event.args) {
+    return (event.args.ipId as ethers.BigNumber).toNumber();
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- create page to become a creator
- create page to upload a design
- wire up registry contract interactions
- expose new routes and navbar links
- update hero button to lead to creator signup

## Testing
- `npm test` *(fails: Hardhat couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684eb0064cdc8329bac48dd8430fe5c3