### PR TITLE
Implement API base utility for auth calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
    - Publish directory : `dist`
 3. Configurer les variables d'environnement :
    - `VITE_API_URL` : URL de l'API backend
+     - Le frontend utilise l'utilitaire `API_BASE` (voir `src/lib/api.ts`) qui se
+       base sur cette variable. Si elle n'est pas renseignée, `/api` sera
+       utilisé par défaut.
    - `VITE_CONTRACT_REGISTRY` : Adresse du contrat MintyShirtRegistry
    - `VITE_CONTRACT_LICENSE` : Adresse du contrat LicenseManager
    - `VITE_CONTRACT_REVENUE` : Adresse du contrat RevenueDistributor

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { API_BASE } from '../lib/api';
 
 export default function LoginPage() {
   const [username, setUsername] = useState('');
@@ -7,7 +8,7 @@ export default function LoginPage() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch('/api/login', {
+    const res = await fetch(`${API_BASE}/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })

--- a/src/components/RegisterPage.tsx
+++ b/src/components/RegisterPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { API_BASE } from '../lib/api';
 
 export default function RegisterPage() {
   const [username, setUsername] = useState('');
@@ -8,7 +9,7 @@ export default function RegisterPage() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch('/api/register', {
+    const res = await fetch(`${API_BASE}/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, email, password })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE: string = import.meta.env.VITE_API_URL || '/api';


### PR DESCRIPTION
## Summary
- add `API_BASE` helper for building API URLs
- use `API_BASE` in login and registration pages
- document the API base fallback behaviour in README

## Testing
- `npm ci`
- `npm test` *(fails: Error HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684ec7e451d483299e7396a7f19f2554