### PR TITLE
Add Auth context for user management

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,85 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { API_BASE } from '../lib/api';
+
+interface UserInfo {
+  id: number;
+  username: string;
+  email: string;
+  role?: string;
+}
+
+interface AuthContextType {
+  user: UserInfo | null;
+  role: string | null;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  role: null,
+  login: async () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<UserInfo | null>(null);
+  const [role, setRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('authUser');
+    const storedRole = localStorage.getItem('authRole');
+    if (stored) {
+      try {
+        setUser(JSON.parse(stored));
+      } catch {
+        /* ignore */
+      }
+    }
+    if (storedRole) {
+      setRole(storedRole);
+    }
+  }, []);
+
+  const login = async (username: string, password: string) => {
+    const res = await fetch(`${API_BASE}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (!res.ok) {
+      throw new Error('Invalid credentials');
+    }
+    const data = await res.json();
+    if (data.token) {
+      localStorage.setItem('authToken', data.token);
+    }
+    localStorage.setItem('authUser', JSON.stringify(data));
+    if (data.role) {
+      localStorage.setItem('authRole', data.role);
+      setRole(data.role);
+    } else {
+      setRole(null);
+      localStorage.removeItem('authRole');
+    }
+    setUser(data);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('authUser');
+    localStorage.removeItem('authRole');
+    setUser(null);
+    setRole(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, role, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,16 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { Web3Provider } from './contexts/Web3Context';
+import { AuthProvider } from './contexts/AuthContext';
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
   createRoot(rootElement).render(
     <React.StrictMode>
       <Web3Provider>
-        <App />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </Web3Provider>
     </React.StrictMode>
   );


### PR DESCRIPTION
## Summary
- provide new `AuthContext` to manage logged-in user and role
- save tokens and user info in `localStorage`
- wrap `App` with `AuthProvider` in main entry

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec983dca88329b89c6cb3aa73996c