### PR TITLE
Add role selection mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import CreatorStatsPage from './components/CreatorStatsPage';
 import WalletConnectPage from './components/WalletConnectPage';
 import BecomeCreatorPage from './components/BecomeCreatorPage';
 import UploadDesignPage from './components/UploadDesignPage';
+import ChooseRolePage from './components/ChooseRolePage';
 
 function App() {
   return (
@@ -38,6 +39,7 @@ function App() {
         <Route path="/design-hub/:id" element={<IpAssetPage />} />
         <Route path="/wallet-connect" element={<WalletConnectPage />} />
         <Route path="/become-creator" element={<BecomeCreatorPage />} />
+        <Route path="/choose-role" element={<ChooseRolePage />} />
         <Route path="/upload-design" element={<UploadDesignPage />} />
         <Route path="/stats" element={<StatsPage />} />
         <Route path="/stats/:creatorHandle" element={<CreatorStatsPage />} />

--- a/src/components/ChooseRolePage.tsx
+++ b/src/components/ChooseRolePage.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
+export default function ChooseRolePage() {
+  const { setRole } = useAuth();
+  const navigate = useNavigate();
+
+  function select(r: 'fan' | 'creator') {
+    setRole(r);
+    if (r === 'creator') {
+      navigate('/become-creator');
+    } else {
+      navigate('/');
+    }
+  }
+
+  return (
+    <div className="font-sans">
+      <Navbar />
+      <div className="p-4 text-white space-y-4 max-w-md mx-auto">
+        <h1 className="text-xl font-bold">Que souhaitez-vous faire ?</h1>
+        <div className="flex space-x-4">
+          <button
+            onClick={() => select('creator')}
+            className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
+          >
+            Activer le mode créateur
+          </button>
+          <button
+            onClick={() => select('fan')}
+            className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
+          >
+            Continuer en tant que fan
+          </button>
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,23 +1,21 @@
 import { useState } from 'react';
-import { API_BASE } from '../lib/api';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function LoginPage() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
+  const { login, user } = useAuth();
+  const navigate = useNavigate();
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch(`${API_BASE}/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    });
-    if (res.ok) {
-      setMessage('Connexion réussie');
-    } else {
-      const data = await res.json().catch(() => ({}));
-      setMessage(data.message || 'Erreur');
+    try {
+      await login(username, password);
+      navigate('/choose-role');
+    } catch (err: any) {
+      setMessage(err.message || 'Erreur');
     }
   }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 import { categories } from '../lib/categories';
 import WalletConnectButton from './WalletConnectButton';
 
@@ -7,6 +8,7 @@ export default function Navbar() {
 
   const [categoriesOpen, setCategoriesOpen] = React.useState(false);
   const closeTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { user, logout, setRole } = useAuth();
 
   const handleEnter = () => {
     if (closeTimeout.current) {
@@ -35,12 +37,29 @@ export default function Navbar() {
             <span className="absolute -top-1 -right-2 bg-purple-600 text-white text-xs rounded-full px-1">0</span>
           </button>
           <WalletConnectButton />
-          <Link
-            to="/login"
-            className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap"
-          >
-            Connexion
-          </Link>
+          {user ? (
+            <>
+              <button
+                onClick={() => setRole(user.role === 'creator' ? 'fan' : 'creator')}
+                className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap"
+              >
+                {user.role === 'creator' ? 'Passer fan' : 'Mode créateur'}
+              </button>
+              <button
+                onClick={logout}
+                className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap"
+              >
+                Déconnexion
+              </button>
+            </>
+          ) : (
+            <Link
+              to="/login"
+              className="bg-purple-500 hover:bg-purple-600 transition-colors text-white px-3 py-1 rounded whitespace-nowrap"
+            >
+              Connexion
+            </Link>
+          )}
         </div>
         <div className="flex items-center space-x-6 pt-2">
           <Link

--- a/src/components/RegisterPage.tsx
+++ b/src/components/RegisterPage.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 import { API_BASE } from '../lib/api';
 
 export default function RegisterPage() {
@@ -6,6 +8,8 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
+  const { login } = useAuth();
+  const navigate = useNavigate();
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -15,7 +19,12 @@ export default function RegisterPage() {
       body: JSON.stringify({ username, email, password })
     });
     if (res.ok) {
-      setMessage('Inscription réussie');
+      try {
+        await login(username, password);
+        navigate('/choose-role');
+      } catch (err: any) {
+        setMessage(err.message || 'Erreur');
+      }
     } else {
       const data = await res.json().catch(() => ({}));
       setMessage(data.message || 'Erreur');


### PR DESCRIPTION
## Summary
- store user role in `AuthContext`
- create role chooser screen
- redirect to role selection after login/registration
- allow switching role via Navbar control

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed1baeb9c832999bb43715fab85be