### PR TITLE
Handle fetch errors gracefully

### DIFF
--- a/src/components/RegisterPage.tsx
+++ b/src/components/RegisterPage.tsx
@@ -13,21 +13,32 @@ export default function RegisterPage() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch(`${API_BASE}/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, email, password })
-    });
-    if (res.ok) {
+    setMessage('');
+    try {
+      const res = await fetch(`${API_BASE}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password })
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        setMessage(data.message || 'Erreur');
+        return;
+      }
+
       try {
         await login(username, password);
         navigate('/choose-role');
       } catch (err: any) {
         setMessage(err.message || 'Erreur');
       }
-    } else {
-      const data = await res.json().catch(() => ({}));
-      setMessage(data.message || 'Erreur');
+    } catch (err: any) {
+      if (err instanceof TypeError) {
+        setMessage('Erreur réseau. Veuillez réessayer plus tard.');
+      } else {
+        setMessage(err.message || 'Erreur');
+      }
     }
   }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -39,23 +39,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const login = async (username: string, password: string) => {
-    const res = await fetch(`${API_BASE}/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
-    });
-    if (!res.ok) {
-      throw new Error('Invalid credentials');
+    try {
+      const res = await fetch(`${API_BASE}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || 'Invalid credentials');
+      }
+
+      const userData: UserInfo = {
+        id: data.id,
+        username: data.username,
+        email: data.email,
+        role: data.role || 'fan',
+      };
+      localStorage.setItem('authUser', JSON.stringify(userData));
+      setUser(userData);
+    } catch (err: any) {
+      if (err instanceof TypeError) {
+        throw new Error('Network error. Please try again later.');
+      }
+      throw err;
     }
-    const data = await res.json();
-    const userData: UserInfo = {
-      id: data.id,
-      username: data.username,
-      email: data.email,
-      role: data.role || 'fan',
-    };
-    localStorage.setItem('authUser', JSON.stringify(userData));
-    setUser(userData);
   };
 
   const logout = () => {


### PR DESCRIPTION
## Summary
- show network errors on registration
- show network errors on login

## Testing
- `npm test` *(fails: Hardhat project missing)*
- `npx hardhat compile` *(fails: couldn't download compiler)*
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_684ed5d28b288329ac2d63472d696f63