### PR TITLE
Remove deprecated creator links

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -96,8 +96,6 @@ export default function Navbar() {
             <Link to="/tokenswap" className="hover:text-purple-300 whitespace-nowrap">TokenSwap</Link>
             <Link to="/design-hub" className="hover:text-purple-300 whitespace-nowrap">DesignHub</Link>
             <Link to="/stats" className="hover:text-purple-300 whitespace-nowrap">Stats</Link>
-            <Link to="/become-creator" className="hover:text-purple-300 whitespace-nowrap">Devenir Créateur</Link>
-            <Link to="/upload-design" className="hover:text-purple-300 whitespace-nowrap">Téléverser un Design</Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove links to becoming a creator and uploading designs from navbar

## Testing
- `npm test` *(fails: Hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eda1a7f9c83298b1bd15a718cf6bf