### PR TITLE
Enable CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
 2. Configurer le service Web :
    - Type : Python
    - Build command : `pip install -r requirements.txt`
+   - Le paquet `Flask-CORS` doit être présent pour autoriser les requêtes CORS
    - Start command : `python -m flask run --host=0.0.0.0 --port=$PORT`
    - Type : Node
    - Build command : `npm install && npm run build`

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Flask
 SQLAlchemy
 requests
 boto3
+Flask-CORS

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -4,10 +4,12 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from flask import Flask, send_from_directory
+from flask_cors import CORS
 from src.models.user import db
 from src.routes.user import user_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
+CORS(app, resources={r"/api/*": {"origins": "*"}})
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
 
 app.register_blueprint(user_bp, url_prefix='/api')

--- a/docs/rapport_deploiement_site_web.md
+++ b/docs/rapport_deploiement_site_web.md
@@ -120,6 +120,8 @@ Les fonctionnalités suivantes ont été implémentées et testées :
 3. Installer les dépendances :
    ```
    pip install -r requirements.txt
+   # Flask-CORS est nécessaire pour les requêtes cross-origin
+   pip install Flask-CORS
    ```
 
 4. Configurer les variables d'environnement :


### PR DESCRIPTION
## Summary
- allow CORS requests to the API
- document Flask-CORS dependency
- add Flask-CORS to the backend requirements

## Testing
- `npm install`
- `npm test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684f26785dd08329b894ffa309f21272