### PR TITLE
Add product images for merch cards

### DIFF
--- a/src/components/AccessoryCategoryPage.tsx
+++ b/src/components/AccessoryCategoryPage.tsx
@@ -13,17 +13,106 @@ interface Product {
   sales: number;
   createdAt: number;
   activity: number;
+  imageUrl: string;
 }
 
 const products: Product[] = [
-  { id: 1, name: 'T-shirt Alpha', creator: 'Alice', price: 0.1, category: 't-shirts', popularity: 80, sales: 120, createdAt: 3, activity: 5 },
-  { id: 2, name: 'T-shirt Beta', creator: 'Bob', price: 0.12, category: 't-shirts', popularity: 70, sales: 80, createdAt: 2, activity: 4 },
-  { id: 3, name: 'Sweat Gamma', creator: 'Clara', price: 0.2, category: 'sweatshirts', popularity: 90, sales: 150, createdAt: 1, activity: 6 },
-  { id: 4, name: 'Casquette Delta', creator: 'Dan', price: 0.05, category: 'casquettes', popularity: 60, sales: 60, createdAt: 5, activity: 2 },
-  { id: 5, name: 'Tote Bag Epsilon', creator: 'Eve', price: 0.03, category: 'tote-bags', popularity: 50, sales: 40, createdAt: 4, activity: 1 },
-  { id: 6, name: 'Poster Zeta', creator: 'Fiona', price: 0.02, category: 'posters', popularity: 40, sales: 30, createdAt: 6, activity: 1 },
-  { id: 7, name: 'Sticker Eta', creator: 'George', price: 0.01, category: 'stickers', popularity: 35, sales: 25, createdAt: 7, activity: 1 },
-  { id: 8, name: 'Produit Gelato', creator: 'Hannah', price: 0.05, category: 'autres', popularity: 20, sales: 10, createdAt: 8, activity: 1 },
+  {
+    id: 1,
+    name: 'T-shirt Alpha',
+    creator: 'Alice',
+    price: 0.1,
+    category: 't-shirts',
+    popularity: 80,
+    sales: 120,
+    createdAt: 3,
+    activity: 5,
+    imageUrl: 'https://via.placeholder.com/300?text=T-shirt+Alpha',
+  },
+  {
+    id: 2,
+    name: 'T-shirt Beta',
+    creator: 'Bob',
+    price: 0.12,
+    category: 't-shirts',
+    popularity: 70,
+    sales: 80,
+    createdAt: 2,
+    activity: 4,
+    imageUrl: 'https://via.placeholder.com/300?text=T-shirt+Beta',
+  },
+  {
+    id: 3,
+    name: 'Sweat Gamma',
+    creator: 'Clara',
+    price: 0.2,
+    category: 'sweatshirts',
+    popularity: 90,
+    sales: 150,
+    createdAt: 1,
+    activity: 6,
+    imageUrl: 'https://via.placeholder.com/300?text=Sweat+Gamma',
+  },
+  {
+    id: 4,
+    name: 'Casquette Delta',
+    creator: 'Dan',
+    price: 0.05,
+    category: 'casquettes',
+    popularity: 60,
+    sales: 60,
+    createdAt: 5,
+    activity: 2,
+    imageUrl: 'https://via.placeholder.com/300?text=Casquette+Delta',
+  },
+  {
+    id: 5,
+    name: 'Tote Bag Epsilon',
+    creator: 'Eve',
+    price: 0.03,
+    category: 'tote-bags',
+    popularity: 50,
+    sales: 40,
+    createdAt: 4,
+    activity: 1,
+    imageUrl: 'https://via.placeholder.com/300?text=Tote+Bag+Epsilon',
+  },
+  {
+    id: 6,
+    name: 'Poster Zeta',
+    creator: 'Fiona',
+    price: 0.02,
+    category: 'posters',
+    popularity: 40,
+    sales: 30,
+    createdAt: 6,
+    activity: 1,
+    imageUrl: 'https://via.placeholder.com/300?text=Poster+Zeta',
+  },
+  {
+    id: 7,
+    name: 'Sticker Eta',
+    creator: 'George',
+    price: 0.01,
+    category: 'stickers',
+    popularity: 35,
+    sales: 25,
+    createdAt: 7,
+    activity: 1,
+    imageUrl: 'https://via.placeholder.com/300?text=Sticker+Eta',
+  },
+  {
+    id: 8,
+    name: 'Produit Gelato',
+    creator: 'Hannah',
+    price: 0.05,
+    category: 'autres',
+    popularity: 20,
+    sales: 10,
+    createdAt: 8,
+    activity: 1,
+    imageUrl: 'https://via.placeholder.com/300?text=Produit+Gelato',
+  },
 ];
 
 export default function AccessoryCategoryPage() {
@@ -64,12 +153,21 @@ export default function AccessoryCategoryPage() {
         </div>
         <div className="grid gap-6 md:grid-cols-3">
           {sorted.map((p) => (
-            <div key={p.id} className="bg-white/10 backdrop-blur border border-purple-800 rounded shadow p-4 flex flex-col items-center text-center text-white">
-              <div className="bg-gray-200 h-40 w-full mb-4" />
+            <div
+              key={p.id}
+              className="bg-white/10 backdrop-blur border border-purple-800 rounded shadow p-4 flex flex-col items-center text-center text-white"
+            >
+              <img
+                src={p.imageUrl}
+                alt={p.name}
+                className="h-40 w-full object-cover mb-4"
+              />
               <h3 className="font-semibold">{p.name}</h3>
               <p className="text-sm text-purple-200">{p.creator}</p>
               <p className="font-bold my-2">{p.price} ETH</p>
-              <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded">Voir</button>
+              <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded">
+                Voir
+              </button>
             </div>
           ))}
         </div>

--- a/src/components/CreatorPage.tsx
+++ b/src/components/CreatorPage.tsx
@@ -9,6 +9,11 @@ import {
   mockMerchProducts,
 } from '../data/mockData';
 
+function getDesignImage(designId: string): string {
+  const design = mockDesigns.find((d) => d.id === designId);
+  return design ? design.imageUrl : 'https://via.placeholder.com/300';
+}
+
 export default function CreatorPage() {
   const { slug } = useParams<{ slug: string }>();
   const creator = mockCreators.find(
@@ -81,6 +86,11 @@ export default function CreatorPage() {
                 key={product.id}
                 className="bg-white/10 border border-purple-800 rounded p-2 text-center"
               >
+                <img
+                  src={getDesignImage(product.designId)}
+                  alt={product.name}
+                  className="w-full h-32 object-cover mb-2"
+                />
                 <p className="font-semibold">{product.name}</p>
                 <p className="text-sm">
                   {product.price} {product.currency}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import { mockMerchProducts, mockDesigns } from '../data/mockData';
 import { Link } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
+
+function getDesignImage(designId: string): string {
+  const design = mockDesigns.find((d) => d.id === designId);
+  return design ? design.imageUrl : 'https://via.placeholder.com/300';
+}
 
 function Hero() {
   return (
@@ -28,18 +34,29 @@ function Hero() {
 }
 
 function BestSellers() {
-  const products = [1, 2, 3];
+  const products = mockMerchProducts.slice(0, 3);
   return (
     <section className="py-12 max-w-7xl mx-auto px-4">
       <h2 className="text-2xl font-bold mb-6 text-white">Meilleures ventes</h2>
       <div className="grid gap-6 md:grid-cols-3">
         {products.map((p) => (
-          <div key={p} className="bg-white/10 backdrop-blur border border-purple-800 rounded shadow p-4 flex flex-col items-center text-center">
-            <div className="bg-gray-200 h-40 w-full mb-4" />
-            <h3 className="font-semibold text-white">Produit {p}</h3>
-            <p className="text-sm text-purple-200">Créateur {p}</p>
-            <p className="font-bold my-2 text-white">0,{p} ETH</p>
-            <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded">Voir</button>
+          <div
+            key={p.id}
+            className="bg-white/10 backdrop-blur border border-purple-800 rounded shadow p-4 flex flex-col items-center text-center"
+          >
+            <img
+              src={getDesignImage(p.designId)}
+              alt={p.name}
+              className="h-40 w-full object-cover mb-4"
+            />
+            <h3 className="font-semibold text-white">{p.name}</h3>
+            <p className="text-sm text-purple-200">{p.type}</p>
+            <p className="font-bold my-2 text-white">
+              {p.price} {p.currency}
+            </p>
+            <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded">
+              Voir
+            </button>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add imageUrl field and placeholder images for accessory category products
- show product images on accessory category cards
- display design images for merch items on creator pages
- show sample merch images on the home page best sellers section

## Testing
- `npm test --silent` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5a9065f88329a961f73d9a104c93