### PR TITLE
Add Render service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
 
 ### Render (Backend)
 1. Connecter le dépôt GitHub
-2. Configurer le service Web :
+2. Utiliser le fichier `render.yaml` à la racine pour configurer le service Node
+
+3. Configurer le service Web :
    - Type : Python
    - Build command : `pip install -r requirements.txt`
    - Le paquet `Flask-CORS` doit être présent pour autoriser les requêtes CORS
@@ -133,7 +135,7 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
    - Type : Node
    - Build command : `npm install && npm run build`
    - Start command : `node server.js`
-3. Configurer les variables d'environnement :
+4. Configurer les variables d'environnement :
    - `FLASK_ENV` : production
    - `SECRET_KEY` : clé secrète pour JWT
    - `DATABASE_URL` : URL de la base de données

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: mintyshirt
+    env: node
+    buildCommand: yarn install && yarn run build
+    startCommand: node server.js
+    envVars:
+      - key: PORT
+        value: 3000


### PR DESCRIPTION
## Summary
- document Render service setup in README
- define Node web service in `render.yaml`

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684fbd17cff48329a825b40bc0876a64