### PR TITLE
Add bilingual category labels

### DIFF
--- a/src/components/CategoriesPage.tsx
+++ b/src/components/CategoriesPage.tsx
@@ -3,9 +3,11 @@ import { Link, useParams } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import { categories } from '../lib/categories';
+import { useLanguage } from '../contexts/LanguageContext';
 
 export default function CategoriesPage() {
   const { slug } = useParams<{ slug?: string }>();
+  const { language } = useLanguage();
 
   if (!slug) {
     return (
@@ -14,13 +16,16 @@ export default function CategoriesPage() {
         <div className="max-w-7xl mx-auto mt-6 px-4 text-white">
           <h1 className="text-3xl font-bold mb-4">Catégories</h1>
           <ul className="space-y-2">
-            {categories.map((cat) => (
-              <li key={cat.slug}>
-                <Link to={`/categories/${cat.slug}`} className="hover:underline">
-                  {cat.name}
-                </Link>
-              </li>
-            ))}
+            {categories.map((cat) => {
+              const label = language === 'fr' ? cat.nameFr : cat.nameEn;
+              return (
+                <li key={cat.slug}>
+                  <Link to={`/categories/${cat.slug}`} className="hover:underline">
+                    {label}
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         </div>
         <Footer />
@@ -35,9 +40,12 @@ export default function CategoriesPage() {
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-2">
         <h1 className="text-3xl font-bold capitalize">
-          {category ? category.name : slug}
+          {category ? (language === 'fr' ? category.nameFr : category.nameEn) : slug}
         </h1>
-        <p>Contenu pour la catégorie {category ? category.name : slug} à venir.</p>
+        <p>
+          Contenu pour la catégorie{' '}
+          {category ? (language === 'fr' ? category.nameFr : category.nameEn) : slug} à venir.
+        </p>
       </div>
       <Footer />
     </div>

--- a/src/components/DesignHubPage.tsx
+++ b/src/components/DesignHubPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import { categories } from '../lib/categories';
+import { useLanguage } from '../contexts/LanguageContext';
 
 interface IPAsset {
   id: number;
@@ -82,6 +83,7 @@ export default function DesignHubPage() {
   const [type, setType] = React.useState('');
   const [order, setOrder] = React.useState('');
   const [country, setCountry] = React.useState('');
+  const { language } = useLanguage();
 
   const filtered = sampleAssets
     .filter((asset) =>
@@ -140,11 +142,14 @@ export default function DesignHubPage() {
               onChange={(e) => setCategory(e.target.value)}
             >
               <option value="">Catégories</option>
-              {categories.map((c) => (
-                <option key={c.slug} value={c.name}>
-                  {c.name}
-                </option>
-              ))}
+              {categories.map((c) => {
+                const label = language === 'fr' ? c.nameFr : c.nameEn;
+                return (
+                  <option key={c.slug} value={c.nameFr}>
+                    {label}
+                  </option>
+                );
+              })}
             </select>
             <select
               className="text-black p-1 rounded"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -90,15 +90,18 @@ export default function Navbar() {
               <div
                 className={`absolute left-0 mt-2 ${categoriesOpen ? 'block' : 'hidden'} bg-white text-gray-900 shadow rounded p-2 space-y-1`}
               >
-                {categories.map((cat) => (
-                  <Link
-                    key={cat.slug}
-                    to={`/categories/${cat.slug}`}
-                    className="block px-2 py-1 hover:bg-purple-100 whitespace-nowrap"
-                  >
-                    {cat.name}
-                  </Link>
-                ))}
+                {categories.map((cat) => {
+                  const label = language === 'fr' ? cat.nameFr : cat.nameEn;
+                  return (
+                    <Link
+                      key={cat.slug}
+                      to={`/categories/${cat.slug}`}
+                      className="block px-2 py-1 hover:bg-purple-100 whitespace-nowrap"
+                    >
+                      {label}
+                    </Link>
+                  );
+                })}
               </div>
             </div>
             <Link to="/royalty-tokens" className="hover:text-purple-300 whitespace-nowrap">{t.navbar.royaltyTokens}</Link>

--- a/src/components/RoyaltyTokensPage.tsx
+++ b/src/components/RoyaltyTokensPage.tsx
@@ -4,6 +4,7 @@ import Navbar from './Navbar';
 import Footer from './Footer';
 import { tokens, SwapToken } from '../lib/tokens';
 import { categories } from '../lib/categories';
+import { useLanguage } from '../contexts/LanguageContext';
 import { FaArrowUp, FaArrowDown, FaMinus } from 'react-icons/fa';
 
 export default function RoyaltyTokensPage() {
@@ -13,6 +14,7 @@ export default function RoyaltyTokensPage() {
   const [minPrice, setMinPrice] = useState('');
   const [maxPrice, setMaxPrice] = useState('');
   const [page, setPage] = useState(1);
+  const { language } = useLanguage();
 
   const ITEMS_PER_PAGE = 6;
 
@@ -73,9 +75,12 @@ export default function RoyaltyTokensPage() {
           <div className="flex flex-wrap items-end space-x-2">
             <select value={category} onChange={e => setCategory(e.target.value)} className="border p-2 text-black">
               <option value="">Catégories</option>
-              {categories.map(c => (
-                <option key={c.slug} value={c.name}>{c.name}</option>
-              ))}
+              {categories.map(c => {
+                const label = language === 'fr' ? c.nameFr : c.nameEn;
+                return (
+                  <option key={c.slug} value={c.nameFr}>{label}</option>
+                );
+              })}
             </select>
             <select value={sort} onChange={e => setSort(e.target.value)} className="border p-2 text-black">
               <option value="popular">Populaires</option>

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import { categories } from '../lib/categories';
+import { useLanguage } from '../contexts/LanguageContext';
 
 interface CreatorStats {
   slug: string;
@@ -86,6 +87,7 @@ export default function StatsPage() {
   const [category, setCategory] = useState('');
   const [sort, setSort] = useState('sales');
   const [country, setCountry] = useState('');
+  const { language } = useLanguage();
 
   const normalizeCategory = (name: string) => {
     const map: Record<string, string> = {
@@ -141,11 +143,14 @@ export default function StatsPage() {
             onChange={(e) => setCategory(e.target.value)}
           >
             <option value="">Catégories</option>
-            {categories.map((cat) => (
-              <option key={cat.slug} value={cat.name}>
-                {cat.name}
-              </option>
-            ))}
+            {categories.map((cat) => {
+              const label = language === 'fr' ? cat.nameFr : cat.nameEn;
+              return (
+                <option key={cat.slug} value={cat.nameFr}>
+                  {label}
+                </option>
+              );
+            })}
           </select>
 
           <select

--- a/src/components/TokenSwapPage.tsx
+++ b/src/components/TokenSwapPage.tsx
@@ -4,6 +4,7 @@ import Navbar from './Navbar';
 import Footer from './Footer';
 import { tokens, SwapToken } from '../lib/tokens';
 import { categories } from '../lib/categories';
+import { useLanguage } from '../contexts/LanguageContext';
 import { FaArrowUp, FaArrowDown, FaMinus } from 'react-icons/fa';
 
 export default function TokenSwapPage() {
@@ -13,6 +14,7 @@ export default function TokenSwapPage() {
   const [minPrice, setMinPrice] = useState('');
   const [maxPrice, setMaxPrice] = useState('');
   const navigate = useNavigate();
+  const { language } = useLanguage();
 
   const filtered = tokens
     .filter(t => t.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -57,9 +59,12 @@ export default function TokenSwapPage() {
           <div className="flex flex-wrap items-end space-x-2">
             <select value={category} onChange={e => setCategory(e.target.value)} className="border p-2 text-black">
               <option value="">Catégories</option>
-              {categories.map(c => (
-                <option key={c.slug} value={c.name}>{c.name}</option>
-              ))}
+              {categories.map(c => {
+                const label = language === 'fr' ? c.nameFr : c.nameEn;
+                return (
+                  <option key={c.slug} value={c.nameFr}>{label}</option>
+                );
+              })}
             </select>
             <select value={sort} onChange={e => setSort(e.target.value)} className="border p-2 text-black">
               <option value="top-sales">Top ventes</option>

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,19 +1,32 @@
 export interface Category {
-  name: string;
   slug: string;
+  nameEn: string;
+  nameFr: string;
 }
 
 export const categories: Category[] = [
-  { name: 'Créateurs de contenu', slug: 'createurs-de-contenu' },
-  { name: 'Musiciens', slug: 'musiciens' },
-  { name: 'Mangas', slug: 'mangas' },
-  { name: 'BD & Animés', slug: 'bd-animes' },
-  { name: 'Jeux vidéo', slug: 'jeux-video' },
-  { name: 'Séries', slug: 'series' },
-  { name: 'Films', slug: 'films' },
-  { name: 'Art visuel', slug: 'art-visuel' },
-  { name: 'Clubs sportifs', slug: 'clubs-sportifs' },
-  { name: 'Crypto', slug: 'crypto' },
-  { name: 'Collections de NFTs', slug: 'collections-de-nfts' },
-  { name: 'Marques & Entreprises', slug: 'marques-entreprises' }
+  {
+    slug: 'createurs-de-contenu',
+    nameEn: 'Content creators',
+    nameFr: 'Créateurs de contenu'
+  },
+  { slug: 'musiciens', nameEn: 'Musicians', nameFr: 'Musiciens' },
+  { slug: 'mangas', nameEn: 'Manga', nameFr: 'Mangas' },
+  { slug: 'bd-animes', nameEn: 'Comics & Anime', nameFr: 'BD & Animés' },
+  { slug: 'jeux-video', nameEn: 'Video games', nameFr: 'Jeux vidéo' },
+  { slug: 'series', nameEn: 'TV shows', nameFr: 'Séries' },
+  { slug: 'films', nameEn: 'Movies', nameFr: 'Films' },
+  { slug: 'art-visuel', nameEn: 'Visual art', nameFr: 'Art visuel' },
+  { slug: 'clubs-sportifs', nameEn: 'Sports clubs', nameFr: 'Clubs sportifs' },
+  { slug: 'crypto', nameEn: 'Crypto', nameFr: 'Crypto' },
+  {
+    slug: 'collections-de-nfts',
+    nameEn: 'NFT collections',
+    nameFr: 'Collections de NFTs'
+  },
+  {
+    slug: 'marques-entreprises',
+    nameEn: 'Brands & Companies',
+    nameFr: 'Marques & Entreprises'
+  }
 ];


### PR DESCRIPTION
## Summary
- add English and French names to category list
- display translated category names in Navbar, categories pages and token pages

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react')*
- `npm test` *(fails: hardhat: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffe4794508329b60681950f5093ed