### PR TITLE
Fix wallet connect button language

### DIFF
--- a/src/components/WalletConnectButton.tsx
+++ b/src/components/WalletConnectButton.tsx
@@ -4,7 +4,7 @@ import { useWeb3 } from '../contexts/Web3Context';
 export default function WalletConnectButton() {
   const { address, connect } = useWeb3();
 
-  const label = address ? `${address.slice(0, 6)}...${address.slice(-4)}` : 'Connecter le portefeuille';
+  const label = address ? `${address.slice(0, 6)}...${address.slice(-4)}` : 'Connect Wallet';
 
   return (
     <button


### PR DESCRIPTION
## Summary
- update wallet connect label to English on homepage

## Testing
- `npm install`
- `npm test` *(fails: not inside a Hardhat project)*

------
https://chatgpt.com/codex/tasks/task_e_685002897f80832984c4d3c39b62cee0