### PR TITLE
Implement translations across pages

### DIFF
--- a/src/components/AccessoryCategoryPage.tsx
+++ b/src/components/AccessoryCategoryPage.tsx
@@ -2,6 +2,24 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    sortPopular: 'Most Popular',
+    sortNew: 'New Arrivals',
+    sortSales: 'Best Sellers',
+    sortActive: 'Most Active',
+    view: 'View',
+  },
+  fr: {
+    sortPopular: 'Plus Populaires',
+    sortNew: 'Nouveaux Ajouts',
+    sortSales: 'Meilleures Ventes',
+    sortActive: 'Plus Actifs',
+    view: 'Voir',
+  },
+} as const;
 
 interface Product {
   id: number;
@@ -117,6 +135,8 @@ const products: Product[] = [
 
 export default function AccessoryCategoryPage() {
   const { category } = useParams();
+  const { language } = useLanguage();
+  const t = texts[language];
   const [sort, setSort] = useState('popular');
 
   const filtered = products.filter((p) => p.category === category);
@@ -145,10 +165,10 @@ export default function AccessoryCategoryPage() {
             value={sort}
             onChange={(e) => setSort(e.target.value)}
           >
-            <option value="popular">Plus Populaires</option>
-            <option value="new">Nouveaux Ajouts</option>
-            <option value="sales">Meilleures Ventes</option>
-            <option value="active">Plus Actifs</option>
+            <option value="popular">{t.sortPopular}</option>
+            <option value="new">{t.sortNew}</option>
+            <option value="sales">{t.sortSales}</option>
+            <option value="active">{t.sortActive}</option>
           </select>
         </div>
         <div className="grid gap-6 md:grid-cols-3">
@@ -166,7 +186,7 @@ export default function AccessoryCategoryPage() {
               <p className="text-sm text-purple-200">{p.creator}</p>
               <p className="font-bold my-2">{p.price} ETH</p>
               <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded">
-                Voir
+                {t.view}
               </button>
             </div>
           ))}

--- a/src/components/CategoriesPage.tsx
+++ b/src/components/CategoriesPage.tsx
@@ -5,16 +5,28 @@ import Footer from './Footer';
 import { categories } from '../lib/categories';
 import { useLanguage } from '../contexts/LanguageContext';
 
+const texts = {
+  en: {
+    title: 'Categories',
+    coming: 'Content for category',
+  },
+  fr: {
+    title: 'Catégories',
+    coming: 'Contenu pour la catégorie',
+  },
+} as const;
+
 export default function CategoriesPage() {
   const { slug } = useParams<{ slug?: string }>();
   const { language } = useLanguage();
+  const t = texts[language];
 
   if (!slug) {
     return (
       <div className="font-sans">
         <Navbar />
         <div className="max-w-7xl mx-auto mt-6 px-4 text-white">
-          <h1 className="text-3xl font-bold mb-4">Catégories</h1>
+          <h1 className="text-3xl font-bold mb-4">{t.title}</h1>
           <ul className="space-y-2">
             {categories.map((cat) => {
               const label = language === 'fr' ? cat.nameFr : cat.nameEn;
@@ -43,8 +55,8 @@ export default function CategoriesPage() {
           {category ? (language === 'fr' ? category.nameFr : category.nameEn) : slug}
         </h1>
         <p>
-          Contenu pour la catégorie{' '}
-          {category ? (language === 'fr' ? category.nameFr : category.nameEn) : slug} à venir.
+          {t.coming}{' '}
+          {category ? (language === 'fr' ? category.nameFr : category.nameEn) : slug}...
         </p>
       </div>
       <Footer />

--- a/src/components/CreatorPage.tsx
+++ b/src/components/CreatorPage.tsx
@@ -2,6 +2,20 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    notFound: 'Creator not found.',
+    designs: 'Designs',
+    merch: 'Merch products',
+  },
+  fr: {
+    notFound: 'Créateur non trouvé.',
+    designs: 'Designs',
+    merch: 'Produits merch',
+  },
+} as const;
 import {
   mockCreators,
   mockIPAssets,
@@ -16,6 +30,8 @@ function getDesignImage(designId: string): string {
 
 export default function CreatorPage() {
   const { slug } = useParams<{ slug: string }>();
+  const { language } = useLanguage();
+  const t = texts[language];
   const creator = mockCreators.find(
     (c) => c.username.slice(1).toLowerCase() === slug
   );
@@ -24,7 +40,7 @@ export default function CreatorPage() {
     return (
       <div className="font-sans">
         <Navbar />
-        <div className="max-w-7xl mx-auto mt-6 px-4 text-white">Créateur non trouvé.</div>
+        <div className="max-w-7xl mx-auto mt-6 px-4 text-white">{t.notFound}</div>
         <Footer />
       </div>
     );
@@ -60,7 +76,7 @@ export default function CreatorPage() {
         </div>
 
         <div>
-          <h2 className="text-2xl font-semibold mb-2">Designs</h2>
+          <h2 className="text-2xl font-semibold mb-2">{t.designs}</h2>
           <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
             {creatorDesigns.map((design) => (
               <div
@@ -79,7 +95,7 @@ export default function CreatorPage() {
         </div>
 
         <div>
-          <h2 className="text-2xl font-semibold mb-2">Produits merch</h2>
+          <h2 className="text-2xl font-semibold mb-2">{t.merch}</h2>
           <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
             {creatorMerch.map((product) => (
               <div

--- a/src/components/CreatorStatsPage.tsx
+++ b/src/components/CreatorStatsPage.tsx
@@ -2,6 +2,34 @@ import React, { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    title: 'Detailed statistics for',
+    subtitle: 'Creator economic performance.',
+    salesChart: 'Sales chart (sample)',
+    tokenChart: 'Token chart (sample)',
+    merchVolume: 'Merch sales volume',
+    itemsSold: 'Items sold',
+    tokenVolume: 'Trading volume',
+    tokenTx: 'Number of transactions',
+    back: 'Back to overall stats',
+    viewProfile: 'View full creator profile',
+  },
+  fr: {
+    title: 'Statistiques détaillées de',
+    subtitle: 'Performances économiques du créateur.',
+    salesChart: 'Graphique ventes (exemple)',
+    tokenChart: 'Graphique tokens (exemple)',
+    merchVolume: 'Volume de ventes de merches',
+    itemsSold: "Nombre d'articles vendus",
+    tokenVolume: 'Volume des échanges',
+    tokenTx: 'Nombre de transactions',
+    back: 'Retour aux statistiques générales',
+    viewProfile: 'Voir le profil complet du créateur',
+  },
+} as const;
 
 interface StatsEntry {
   date: string;
@@ -31,6 +59,8 @@ const periods = [
 
 export default function CreatorStatsPage() {
   const { creatorHandle } = useParams<{ creatorHandle: string }>();
+  const { language } = useLanguage();
+  const t = texts[language];
   const [period, setPeriod] = useState('7d');
 
   const current = sampleData; // would be filtered by period in a real app
@@ -44,8 +74,8 @@ export default function CreatorStatsPage() {
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-6">
         <div>
-          <h1 className="text-3xl font-bold mb-1">Statistiques détaillées de {creatorHandle}</h1>
-          <p className="text-sm">Performances économiques du créateur.</p>
+          <h1 className="text-3xl font-bold mb-1">{t.title} {creatorHandle}</h1>
+          <p className="text-sm">{t.subtitle}</p>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
@@ -63,20 +93,20 @@ export default function CreatorStatsPage() {
         <div className="grid md:grid-cols-2 gap-6">
           <div className="space-y-2">
             <div className="h-48 bg-white/10 border border-purple-800 rounded flex items-center justify-center">
-              Graphique ventes (exemple)
+              {t.salesChart}
             </div>
             <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-1">
-              <div className="font-semibold">Volume de ventes de merches : {merchVolume} €</div>
-              <div className="font-semibold">Nombre d'articles vendus : {itemsSold}</div>
+              <div className="font-semibold">{t.merchVolume} : {merchVolume} €</div>
+              <div className="font-semibold">{t.itemsSold} : {itemsSold}</div>
             </div>
           </div>
           <div className="space-y-2">
             <div className="h-48 bg-white/10 border border-purple-800 rounded flex items-center justify-center">
-              Graphique tokens (exemple)
+              {t.tokenChart}
             </div>
             <div className="bg-white/10 border border-purple-800 rounded p-4 space-y-1">
-              <div className="font-semibold">Volume des échanges : {tokenVolume} ETH</div>
-              <div className="font-semibold">Nombre de transactions : {tokenTx}</div>
+              <div className="font-semibold">{t.tokenVolume} : {tokenVolume} ETH</div>
+              <div className="font-semibold">{t.tokenTx} : {tokenTx}</div>
             </div>
           </div>
         </div>
@@ -86,13 +116,13 @@ export default function CreatorStatsPage() {
             to="/stats"
             className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
           >
-            Retour aux statistiques générales
+            {t.back}
           </Link>
           <Link
             to={`/creators/${creatorHandle}`}
             className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
           >
-            Voir le profil complet du créateur
+            {t.viewProfile}
           </Link>
         </div>
       </div>

--- a/src/components/IpAssetPage.tsx
+++ b/src/components/IpAssetPage.tsx
@@ -2,15 +2,27 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    details: 'IP Asset details coming soon.',
+  },
+  fr: {
+    details: "Détails de l'IP Asset à venir.",
+  },
+} as const;
 
 export default function IpAssetPage() {
   const { id } = useParams<{ id: string }>();
+  const { language } = useLanguage();
+  const t = texts[language];
   return (
     <div className="font-sans">
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-2">
         <h1 className="text-3xl font-bold">IP Asset {id}</h1>
-        <p>Détails de l'IP Asset à venir.</p>
+        <p>{t.details}</p>
       </div>
       <Footer />
     </div>

--- a/src/components/RoyaltyTokensPage.tsx
+++ b/src/components/RoyaltyTokensPage.tsx
@@ -5,6 +5,57 @@ import Footer from './Footer';
 import { tokens, SwapToken } from '../lib/tokens';
 import { categories } from '../lib/categories';
 import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    title: 'Royalty Tokens',
+    search: 'Search for a token or creator',
+    categories: 'Categories',
+    sortPopular: 'Popular',
+    sortPrice: 'Price',
+    sortRecent: 'Recent',
+    sortShare: '% revenue',
+    min: 'Min',
+    max: 'Max',
+    creator: 'Creator',
+    currentPrice: 'Current price',
+    change24h: '24h change',
+    volume24h: '24h volume',
+    revenueShare: 'Revenue share',
+    ipAsset: 'IP Asset',
+    view: 'View',
+    perks: 'Perks',
+    viewToken: 'View Token',
+    prev: 'Previous',
+    next: 'Next',
+    disclaimer:
+      'Royalty Tokens offered on MintyShirt are not security tokens and do not guarantee returns. Holders earn revenue only if the creator generates sales.',
+  },
+  fr: {
+    title: 'Royalty Tokens',
+    search: 'Rechercher un token ou un créateur',
+    categories: 'Catégories',
+    sortPopular: 'Populaires',
+    sortPrice: 'Prix',
+    sortRecent: 'Récents',
+    sortShare: '% revenus',
+    min: 'Min',
+    max: 'Max',
+    creator: 'Créateur',
+    currentPrice: 'Prix actuel',
+    change24h: 'Évolution 24h',
+    volume24h: 'Volume 24h',
+    revenueShare: '% revenus partagés',
+    ipAsset: 'IP Asset',
+    view: 'Voir',
+    perks: 'Avantages',
+    viewToken: 'Voir le Token',
+    prev: 'Précédent',
+    next: 'Suivant',
+    disclaimer:
+      'Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.',
+  },
+} as const;
 import { FaArrowUp, FaArrowDown, FaMinus } from 'react-icons/fa';
 
 export default function RoyaltyTokensPage() {
@@ -15,6 +66,7 @@ export default function RoyaltyTokensPage() {
   const [maxPrice, setMaxPrice] = useState('');
   const [page, setPage] = useState(1);
   const { language } = useLanguage();
+  const t = texts[language];
 
   const ITEMS_PER_PAGE = 6;
 
@@ -62,19 +114,19 @@ export default function RoyaltyTokensPage() {
     <div className="font-sans">
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-4">
-        <h1 className="text-3xl font-bold">Royalty Tokens</h1>
+        <h1 className="text-3xl font-bold">{t.title}</h1>
 
         <div className="bg-white/10 backdrop-blur p-4 rounded border border-purple-800 space-y-2">
           <input
             type="text"
-            placeholder="Rechercher un token ou un créateur"
+            placeholder={t.search}
             value={search}
             onChange={e => setSearch(e.target.value)}
             className="border p-2 text-black w-full md:w-1/2"
           />
           <div className="flex flex-wrap items-end space-x-2">
             <select value={category} onChange={e => setCategory(e.target.value)} className="border p-2 text-black">
-              <option value="">Catégories</option>
+              <option value="">{t.categories}</option>
               {categories.map(c => {
                 const label = language === 'fr' ? c.nameFr : c.nameEn;
                 return (
@@ -83,52 +135,52 @@ export default function RoyaltyTokensPage() {
               })}
             </select>
             <select value={sort} onChange={e => setSort(e.target.value)} className="border p-2 text-black">
-              <option value="popular">Populaires</option>
-              <option value="price">Prix</option>
-              <option value="recent">Récents</option>
-              <option value="share">% revenus</option>
+              <option value="popular">{t.sortPopular}</option>
+              <option value="price">{t.sortPrice}</option>
+              <option value="recent">{t.sortRecent}</option>
+              <option value="share">{t.sortShare}</option>
             </select>
-            <input type="number" placeholder="Min" value={minPrice} onChange={e => setMinPrice(e.target.value)} className="border p-2 text-black w-24" />
-            <input type="number" placeholder="Max" value={maxPrice} onChange={e => setMaxPrice(e.target.value)} className="border p-2 text-black w-24" />
+            <input type="number" placeholder={t.min} value={minPrice} onChange={e => setMinPrice(e.target.value)} className="border p-2 text-black w-24" />
+            <input type="number" placeholder={t.max} value={maxPrice} onChange={e => setMaxPrice(e.target.value)} className="border p-2 text-black w-24" />
           </div>
         </div>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {paginated.map((t: SwapToken) => (
-            <div key={t.id} className="bg-white/10 backdrop-blur border border-purple-800 rounded shadow p-4 space-y-2">
+          {paginated.map((token: SwapToken) => (
+            <div key={token.id} className="bg-white/10 backdrop-blur border border-purple-800 rounded shadow p-4 space-y-2">
               <div className="flex items-center space-x-2">
-                <div className="text-2xl">{t.logo}</div>
-                <h3 className="font-semibold">{t.name}</h3>
+                <div className="text-2xl">{token.logo}</div>
+                <h3 className="font-semibold">{token.name}</h3>
               </div>
               <div>
-                Créateur:
-                <Link to={`/creators/${t.creatorSlug}`} className="text-purple-300 hover:underline ml-1">
-                  {t.creator}
+                {t.creator}:
+                <Link to={`/creators/${token.creatorSlug}`} className="text-purple-300 hover:underline ml-1">
+                  {token.creator}
                 </Link>
               </div>
-              <div>Prix actuel: {t.lastPrice} ETH</div>
-              <div>Évolution 24h: {changeIcon(t.change24h)}</div>
-              <div>Volume 24h: {t.volume24h} ETH</div>
-              <div>% revenus partagés: {t.revenueShare}%</div>
+              <div>{t.currentPrice}: {token.lastPrice} ETH</div>
+              <div>{t.change24h}: {changeIcon(token.change24h)}</div>
+              <div>{t.volume24h}: {token.volume24h} ETH</div>
+              <div>{t.revenueShare}: {token.revenueShare}%</div>
               <div>
-                IP Asset:
-                <Link to={`/design-hub/${t.ipAssetId}`} className="text-purple-300 hover:underline ml-1">
-                  Voir
+                {t.ipAsset}:
+                <Link to={`/design-hub/${token.ipAssetId}`} className="text-purple-300 hover:underline ml-1">
+                  {t.view}
                 </Link>
               </div>
               <div>
-                <div className="font-semibold">Avantages</div>
+                <div className="font-semibold">{t.perks}</div>
                 <ul className="list-disc list-inside text-sm space-y-1">
-                  {t.perks.map(p => (
+                  {token.perks.map(p => (
                     <li key={p}>{p}</li>
                   ))}
                 </ul>
               </div>
               <Link
-                to={`/tokenswap/${t.id}`}
+                to={`/tokenswap/${token.id}`}
                 className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded text-center block"
               >
-                Voir le Token
+                {t.viewToken}
               </Link>
             </div>
           ))}
@@ -141,7 +193,7 @@ export default function RoyaltyTokensPage() {
               disabled={page === 1}
               className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded disabled:opacity-50"
             >
-              Précédent
+              {t.prev}
             </button>
             <span>
               Page {page} / {pageCount}
@@ -151,14 +203,12 @@ export default function RoyaltyTokensPage() {
               disabled={page === pageCount}
               className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded disabled:opacity-50"
             >
-              Suivant
+              {t.next}
             </button>
           </div>
         )}
 
-        <p className="text-sm mt-4">
-          Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier, mais représentent un droit à redevance lié à l’usage commercial d’une œuvre ou d’une marque, déterminé par le créateur lui-même. MintyShirt ne garantit aucun rendement. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.
-        </p>
+        <p className="text-sm mt-4">{t.disclaimer}</p>
       </div>
       <Footer />
     </div>

--- a/src/components/ShopPage.tsx
+++ b/src/components/ShopPage.tsx
@@ -2,6 +2,22 @@ import { Link } from 'react-router-dom';
 import Navbar from './Navbar';
 import React from 'react';
 import Footer from './Footer';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    title: 'Shop',
+    description: 'Find merch from your favourite creators and discover new inspiration.',
+    accessories: 'Accessories',
+    select: 'Select an accessory type to view products.',
+  },
+  fr: {
+    title: 'La Boutique',
+    description: 'Trouvez le merch de vos créateurs préférés et découvrez de nouvelles inspirations.',
+    accessories: 'Accessoires',
+    select: "Sélectionnez un type d'accessoire pour afficher les produits.",
+  },
+} as const;
 
 const accessories = [
   { name: 'T-shirts', path: 't-shirts' },
@@ -19,21 +35,20 @@ const accessories = [
 ];
 
 export default function ShopPage() {
-  // TODO: replace hardcoded language logic with context/i18n when available
-  const language = 'fr';
-  const title = language === 'fr' ? 'La Boutique' : 'Shop';
+  const { language } = useLanguage();
+  const t = texts[language];
   return (
     <div className="font-sans">
       <Navbar />
       <h1 className="text-3xl font-bold text-white max-w-7xl mx-auto mt-6 px-4">
-        {title}
+        {t.title}
       </h1>
       <p className="text-white max-w-7xl mx-auto mt-2 px-4">
-        Trouvez le merch de vos créateurs préférés et découvrez de nouvelles inspirations.
+        {t.description}
       </p>
       <div className="flex max-w-7xl mx-auto mt-4 px-4 space-x-6">
         <aside className="w-48">
-          <h2 className="font-bold mb-2 text-white">Accessoires</h2>
+          <h2 className="font-bold mb-2 text-white">{t.accessories}</h2>
           <ul className="space-y-1">
             {accessories.map((a) => (
               <li key={a.path}>
@@ -45,7 +60,7 @@ export default function ShopPage() {
           </ul>
         </aside>
         <div className="flex-1 text-white">
-          <p>Sélectionnez un type d&apos;accessoire pour afficher les produits.</p>
+          <p>{t.select}</p>
         </div>
       </div>
       <Footer />

--- a/src/components/StatsPage.tsx
+++ b/src/components/StatsPage.tsx
@@ -5,6 +5,45 @@ import Footer from './Footer';
 import { categories } from '../lib/categories';
 import { useLanguage } from '../contexts/LanguageContext';
 
+const texts = {
+  en: {
+    title: 'Statistics',
+    subtitle: 'Overview of sales and activity.',
+    description:
+      'Track creators\' performance on MintyShirt. Rankings are based on merch sales, token activity and community engagement.',
+    categories: 'Categories',
+    sortSales: 'Top merch sales',
+    sortTokens: 'Most traded tokens',
+    sortGroup: 'Most active groups',
+    sortNew: 'New creators',
+    country: 'Country',
+    viewStats: 'View detailed stats',
+    viewCreator: 'View creator page',
+    legend: 'Legend',
+    legendUpdated: 'Figures are updated every 24h.',
+    legendVolume: 'TokenSwap volume reflects secondary sales.',
+    legendMerch: 'Merch revenue only counts products sold via MintyShirt.',
+  },
+  fr: {
+    title: 'Statistiques',
+    subtitle: 'Aperçu des ventes et activités.',
+    description:
+      "Suivez les performances économiques des créateurs actifs sur MintyShirt. Classement basé sur les ventes de produits, l’activité liée aux tokens, et l'engagement communautaire.",
+    categories: 'Catégories',
+    sortSales: 'Meilleures ventes merch',
+    sortTokens: 'Tokens les plus échangés',
+    sortGroup: 'Groupes les plus actifs',
+    sortNew: 'Nouveaux créateurs',
+    country: 'Pays',
+    viewStats: 'Voir les statistiques détaillées',
+    viewCreator: 'Voir la page du créateur',
+    legend: 'Légende',
+    legendUpdated: 'Les chiffres sont actualisés toutes les 24h.',
+    legendVolume: 'Le volume TokenSwap correspond aux ventes secondaires de tokens.',
+    legendMerch: 'Les revenus merch incluent uniquement les produits vendus via MintyShirt.',
+  },
+} as const;
+
 interface CreatorStats {
   slug: string;
   username: string;
@@ -88,6 +127,7 @@ export default function StatsPage() {
   const [sort, setSort] = useState('sales');
   const [country, setCountry] = useState('');
   const { language } = useLanguage();
+  const t = texts[language];
 
   const normalizeCategory = (name: string) => {
     const map: Record<string, string> = {
@@ -125,13 +165,9 @@ export default function StatsPage() {
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-6">
         <div>
-          <h1 className="text-3xl font-bold mb-1">Statistiques</h1>
-          <p className="text-sm">Aperçu des ventes et activités.</p>
-          <p className="text-sm mt-1">
-            Suivez les performances économiques des créateurs actifs sur
-            MintyShirt. Classement basé sur les ventes de produits, l’activité
-            liée aux tokens, et l'engagement communautaire.
-          </p>
+          <h1 className="text-3xl font-bold mb-1">{t.title}</h1>
+          <p className="text-sm">{t.subtitle}</p>
+          <p className="text-sm mt-1">{t.description}</p>
         </div>
 
 
@@ -142,7 +178,7 @@ export default function StatsPage() {
             value={category}
             onChange={(e) => setCategory(e.target.value)}
           >
-            <option value="">Catégories</option>
+            <option value="">{t.categories}</option>
             {categories.map((cat) => {
               const label = language === 'fr' ? cat.nameFr : cat.nameEn;
               return (
@@ -158,10 +194,10 @@ export default function StatsPage() {
             value={sort}
             onChange={(e) => setSort(e.target.value)}
           >
-            <option value="sales">Meilleures ventes merch</option>
-            <option value="tokens">Tokens les plus échangés</option>
-            <option value="group">Groupes les plus actifs</option>
-            <option value="new">Nouveaux créateurs</option>
+            <option value="sales">{t.sortSales}</option>
+            <option value="tokens">{t.sortTokens}</option>
+            <option value="group">{t.sortGroup}</option>
+            <option value="new">{t.sortNew}</option>
           </select>
 
           <select
@@ -169,7 +205,7 @@ export default function StatsPage() {
             value={country}
             onChange={(e) => setCountry(e.target.value)}
           >
-            <option value="">Pays</option>
+            <option value="">{t.country}</option>
             {countries.map((c) => (
               <option key={c} value={c}>
                 {c}
@@ -196,26 +232,23 @@ export default function StatsPage() {
                 to={`/stats/${creator.slug}`}
                 className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded inline-block mt-2"
               >
-                Voir les statistiques détaillées
+                {t.viewStats}
               </Link>
               <Link
                 to={`/creators/${creator.slug}`}
                 className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-3 py-1 rounded inline-block mt-2"
               >
-                Voir la page du créateur
+                {t.viewCreator}
               </Link>
             </div>
           ))}
         </div>
 
         <div className="text-sm space-y-1">
-          <h2 className="font-semibold">Légende</h2>
-          <p>Les chiffres sont actualisés toutes les 24h.</p>
-          <p>Le volume TokenSwap correspond aux ventes secondaires de tokens.</p>
-          <p>
-            Les revenus merch incluent uniquement les produits vendus via
-            MintyShirt.
-          </p>
+          <h2 className="font-semibold">{t.legend}</h2>
+          <p>{t.legendUpdated}</p>
+          <p>{t.legendVolume}</p>
+          <p>{t.legendMerch}</p>
         </div>
       </div>
       <Footer />

--- a/src/components/TokenDetailPage.tsx
+++ b/src/components/TokenDetailPage.tsx
@@ -4,10 +4,48 @@ import Navbar from './Navbar';
 import Footer from './Footer';
 import { tokens } from '../lib/tokens';
 import { FaCheck } from 'react-icons/fa';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    creator: 'Creator',
+    category: 'Category',
+    ipPage: 'Associated IP page',
+    view: 'View IP',
+    lastPrice: 'Last traded price',
+    volume24h: '24h volume',
+    holders: 'Holders',
+    revenueShare: '% revenue shared',
+    perks: 'Associated perks',
+    buyNow: 'Buy now',
+    viewShop: "View on creator's shop", 
+    notFound: 'Token not found',
+    disclaimer:
+      'Royalty Tokens offered on MintyShirt are not security tokens and do not guarantee returns. Holders earn revenue only if the creator generates sales.',
+  },
+  fr: {
+    creator: 'Créateur',
+    category: 'Catégorie',
+    ipPage: 'Page IP associée',
+    view: "Voir l'actif IP",
+    lastPrice: 'Dernier prix échangé',
+    volume24h: 'Volume 24h',
+    holders: 'Nombre de détenteurs',
+    revenueShare: '% des revenus redistribués',
+    perks: 'Avantages associés',
+    buyNow: 'Acheter maintenant',
+    viewShop: 'Voir sur la boutique du créateur',
+    notFound: 'Token introuvable',
+    disclaimer:
+      'Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.',
+  },
+} as const;
 
 export default function TokenDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const token = tokens.find(t => t.id === id);
+  const { language } = useLanguage();
+  const t = texts[language];
+  const token = tokens.find(tk => tk.id === id);
 
   return (
     <div className="font-sans">
@@ -20,29 +58,29 @@ export default function TokenDetailPage() {
               <h1 className="text-3xl font-bold">{token.name}</h1>
             </div>
             <div>
-              Créateur:
+              {t.creator}:
               <Link to={`/creators/${token.creatorSlug}`} className="text-purple-300 hover:underline ml-1">
                 {token.creator}
               </Link>
             </div>
-            <div>Catégorie: {token.category}</div>
+            <div>{t.category}: {token.category}</div>
             <div>
-              Page IP associée:
+              {t.ipPage}:
               <Link to={`/design-hub/${token.ipAssetId}`} className="text-purple-300 hover:underline ml-1">
-                Voir l'actif IP
+                {t.view}
               </Link>
             </div>
             <p>{token.description}</p>
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="bg-white/10 backdrop-blur border border-purple-800 rounded p-4 space-y-1">
-                <div>Dernier prix échangé: {token.lastPrice} ETH</div>
-                <div>Volume 24h: {token.volume24h} ETH</div>
-                <div>Nombre de détenteurs: {token.holders}</div>
-                <div>% des revenus redistribués: {token.revenueShare}%</div>
+                <div>{t.lastPrice}: {token.lastPrice} ETH</div>
+                <div>{t.volume24h}: {token.volume24h} ETH</div>
+                <div>{t.holders}: {token.holders}</div>
+                <div>{t.revenueShare}: {token.revenueShare}%</div>
               </div>
               <div className="bg-white/10 backdrop-blur border border-purple-800 rounded p-4">
-                <div className="font-semibold mb-2">Avantages associés</div>
+                <div className="font-semibold mb-2">{t.perks}</div>
                 <ul className="space-y-1">
                   {token.perks.map(p => (
                     <li key={p} className="flex items-center">
@@ -56,20 +94,18 @@ export default function TokenDetailPage() {
 
             <div className="space-x-2">
               <button className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded">
-                Acheter maintenant
+                {t.buyNow}
               </button>
               <Link to={`/creators/${token.creatorSlug}`} className="bg-blue-600 hover:bg-blue-700 transition-colors text-white px-4 py-2 rounded">
-                Voir sur la boutique du créateur
+                {t.viewShop}
               </Link>
             </div>
           </>
         ) : (
-          <h1 className="text-3xl font-bold">Token introuvable</h1>
+          <h1 className="text-3xl font-bold">{t.notFound}</h1>
         )}
 
-        <p className="text-sm mt-8">
-          Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier, mais représentent un droit à redevance lié à l’usage commercial d’une œuvre ou d’une marque, déterminé par le créateur lui-même. MintyShirt ne garantit aucun rendement. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.
-        </p>
+        <p className="text-sm mt-8">{t.disclaimer}</p>
       </div>
       <Footer />
     </div>

--- a/src/components/TokenSwapPage.tsx
+++ b/src/components/TokenSwapPage.tsx
@@ -5,6 +5,53 @@ import Footer from './Footer';
 import { tokens, SwapToken } from '../lib/tokens';
 import { categories } from '../lib/categories';
 import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    title: 'TokenSwap - Royalty Tokens secondary market',
+    subtitle: 'Trade your tokens here.',
+    search: 'Search for a token or creator',
+    categories: 'Categories',
+    sortTopSales: 'Top sales',
+    sortTopPrice: 'Top price',
+    sortRecent: 'Recent',
+    sortPopular: 'Popular',
+    min: 'Min',
+    max: 'Max',
+    logo: 'Logo',
+    name: 'Name',
+    creator: 'Creator',
+    lastPrice: 'Last price',
+    change24h: '24h',
+    volume24h: '24h volume',
+    onSale: 'On sale',
+    buy: 'Buy',
+    disclaimer:
+      'Royalty Tokens offered on MintyShirt are not security tokens and do not guarantee returns. Holders earn revenue only if the creator generates sales.',
+  },
+  fr: {
+    title: 'TokenSwap - Marché secondaire des Royalty Tokens',
+    subtitle: 'Échangez vos tokens ici.',
+    search: 'Rechercher un token ou un créateur',
+    categories: 'Catégories',
+    sortTopSales: 'Top ventes',
+    sortTopPrice: 'Top prix',
+    sortRecent: 'Récents',
+    sortPopular: 'Populaires',
+    min: 'Min',
+    max: 'Max',
+    logo: 'Logo',
+    name: 'Nom',
+    creator: 'Créateur',
+    lastPrice: 'Dernier prix',
+    change24h: '24h',
+    volume24h: 'Volume 24h',
+    onSale: 'En vente',
+    buy: 'Acheter',
+    disclaimer:
+      'Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.',
+  },
+} as const;
 import { FaArrowUp, FaArrowDown, FaMinus } from 'react-icons/fa';
 
 export default function TokenSwapPage() {
@@ -15,6 +62,7 @@ export default function TokenSwapPage() {
   const [maxPrice, setMaxPrice] = useState('');
   const navigate = useNavigate();
   const { language } = useLanguage();
+  const t = texts[language];
 
   const filtered = tokens
     .filter(t => t.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -46,19 +94,19 @@ export default function TokenSwapPage() {
     <div className="font-sans">
       <Navbar />
       <div className="max-w-7xl mx-auto mt-6 px-4 text-white space-y-4">
-        <h1 className="text-3xl font-bold">TokenSwap - Marché secondaire des Royalty Tokens</h1>
-        <p>Échangez vos tokens ici.</p>
+        <h1 className="text-3xl font-bold">{t.title}</h1>
+        <p>{t.subtitle}</p>
         <div className="bg-white/10 backdrop-blur p-4 rounded border border-purple-800 space-y-2">
           <input
             type="text"
-            placeholder="Rechercher un token ou un créateur"
+            placeholder={t.search}
             value={search}
             onChange={e => setSearch(e.target.value)}
             className="border p-2 text-black w-full md:w-1/2"
           />
           <div className="flex flex-wrap items-end space-x-2">
             <select value={category} onChange={e => setCategory(e.target.value)} className="border p-2 text-black">
-              <option value="">Catégories</option>
+              <option value="">{t.categories}</option>
               {categories.map(c => {
                 const label = language === 'fr' ? c.nameFr : c.nameEn;
                 return (
@@ -67,13 +115,13 @@ export default function TokenSwapPage() {
               })}
             </select>
             <select value={sort} onChange={e => setSort(e.target.value)} className="border p-2 text-black">
-              <option value="top-sales">Top ventes</option>
-              <option value="top-price">Top prix</option>
-              <option value="recent">Récents</option>
-              <option value="popular">Populaires</option>
+              <option value="top-sales">{t.sortTopSales}</option>
+              <option value="top-price">{t.sortTopPrice}</option>
+              <option value="recent">{t.sortRecent}</option>
+              <option value="popular">{t.sortPopular}</option>
             </select>
-            <input type="number" placeholder="Min" value={minPrice} onChange={e => setMinPrice(e.target.value)} className="border p-2 text-black w-24" />
-            <input type="number" placeholder="Max" value={maxPrice} onChange={e => setMaxPrice(e.target.value)} className="border p-2 text-black w-24" />
+            <input type="number" placeholder={t.min} value={minPrice} onChange={e => setMinPrice(e.target.value)} className="border p-2 text-black w-24" />
+            <input type="number" placeholder={t.max} value={maxPrice} onChange={e => setMaxPrice(e.target.value)} className="border p-2 text-black w-24" />
           </div>
         </div>
 
@@ -81,31 +129,31 @@ export default function TokenSwapPage() {
           <table className="min-w-full text-sm border border-purple-800">
             <thead className="bg-purple-800/50">
               <tr>
-                <th className="px-2 py-1">Logo</th>
-                <th className="px-2 py-1 text-left">Nom</th>
-                <th className="px-2 py-1 text-left">Créateur</th>
-                <th className="px-2 py-1 text-right">Dernier prix</th>
-                <th className="px-2 py-1 text-right">24h</th>
-                <th className="px-2 py-1 text-right">Volume 24h</th>
-                <th className="px-2 py-1 text-right">En vente</th>
+                <th className="px-2 py-1">{t.logo}</th>
+                <th className="px-2 py-1 text-left">{t.name}</th>
+                <th className="px-2 py-1 text-left">{t.creator}</th>
+                <th className="px-2 py-1 text-right">{t.lastPrice}</th>
+                <th className="px-2 py-1 text-right">{t.change24h}</th>
+                <th className="px-2 py-1 text-right">{t.volume24h}</th>
+                <th className="px-2 py-1 text-right">{t.onSale}</th>
                 <th className="px-2 py-1" />
               </tr>
             </thead>
             <tbody>
-              {sorted.map(t => (
-                <tr key={t.id} className="hover:bg-white/10 cursor-pointer" onClick={() => navigate(`/tokenswap/${t.id}`)}>
-                  <td className="px-2 py-1 text-center">{t.logo}</td>
-                  <td className="px-2 py-1">{t.name}</td>
-                  <td className="px-2 py-1">{t.creator}</td>
-                  <td className="px-2 py-1 text-right">{t.lastPrice} ETH</td>
-                  <td className="px-2 py-1 text-right">{changeIcon(t.change24h)}</td>
-                  <td className="px-2 py-1 text-right">{t.volume24h} ETH</td>
-                  <td className="px-2 py-1 text-right">{t.quantity}</td>
+              {sorted.map(token => (
+                <tr key={token.id} className="hover:bg-white/10 cursor-pointer" onClick={() => navigate(`/tokenswap/${token.id}`)}>
+                  <td className="px-2 py-1 text-center">{token.logo}</td>
+                  <td className="px-2 py-1">{token.name}</td>
+                  <td className="px-2 py-1">{token.creator}</td>
+                  <td className="px-2 py-1 text-right">{token.lastPrice} ETH</td>
+                  <td className="px-2 py-1 text-right">{changeIcon(token.change24h)}</td>
+                  <td className="px-2 py-1 text-right">{token.volume24h} ETH</td>
+                  <td className="px-2 py-1 text-right">{token.quantity}</td>
                   <td className="px-2 py-1">
                     <button
                       className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-2 py-1 rounded"
                       onClick={e => { e.stopPropagation(); }}
-                    >Acheter</button>
+                    >{t.buy}</button>
                   </td>
                 </tr>
               ))}
@@ -113,9 +161,7 @@ export default function TokenSwapPage() {
           </table>
         </div>
 
-        <p className="text-sm mt-4">
-          Les Royalty Tokens proposés sur MintyShirt ne sont pas des security tokens. Ils ne constituent pas une promesse de gain financier, mais représentent un droit à redevance lié à l’usage commercial d’une œuvre ou d’une marque, déterminé par le créateur lui-même. MintyShirt ne garantit aucun rendement. Le détenteur touche des revenus uniquement si l’activité du créateur génère des ventes.
-        </p>
+        <p className="text-sm mt-4">{t.disclaimer}</p>
       </div>
       <Footer />
     </div>

--- a/src/components/UploadDesignPage.tsx
+++ b/src/components/UploadDesignPage.tsx
@@ -1,11 +1,41 @@
 import React, { useState } from 'react';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    title: 'Upload a Design',
+    connect: 'Connect Wallet',
+    name: 'Design name',
+    description: 'Description',
+    ipfs: 'IPFS hash or URL',
+    type: 'Content type',
+    allowAI: 'Allow AI training',
+    save: 'Save design',
+    saving: 'Saving...',
+    saved: 'Design saved with ID:',
+  },
+  fr: {
+    title: 'Téléverser un Design',
+    connect: 'Connecter Wallet',
+    name: 'Nom du design',
+    description: 'Description',
+    ipfs: 'Hash IPFS ou URL',
+    type: 'Type de contenu',
+    allowAI: "Autoriser l'entraînement IA",
+    save: 'Enregistrer le design',
+    saving: 'Enregistrement...',
+    saved: "Design enregistré avec l'ID :",
+  },
+} as const;
 import { useWeb3 } from '../contexts/Web3Context';
 import { getCreatorId, registerIPAsset } from '../services/registry';
 
 export default function UploadDesignPage() {
   const { provider, connect, address } = useWeb3();
+  const { language } = useLanguage();
+  const t = texts[language];
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [ipfsHash, setIpfsHash] = useState('');
@@ -46,38 +76,38 @@ export default function UploadDesignPage() {
     <div className="font-sans">
       <Navbar />
       <div className="max-w-md mx-auto mt-6 p-4 text-white space-y-4">
-        <h1 className="text-2xl font-bold">Téléverser un Design</h1>
+        <h1 className="text-2xl font-bold">{t.title}</h1>
         {!address && (
           <button
             onClick={connect}
             className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
           >
-            Connecter Wallet
+            {t.connect}
           </button>
         )}
         {address && (
           <form onSubmit={submit} className="space-y-2">
             <input
               className="w-full border p-2 text-black"
-              placeholder="Nom du design"
+              placeholder={t.name}
               value={name}
               onChange={(e) => setName(e.target.value)}
             />
             <textarea
               className="w-full border p-2 text-black"
-              placeholder="Description"
+              placeholder={t.description}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
             />
             <input
               className="w-full border p-2 text-black"
-              placeholder="Hash IPFS ou URL"
+              placeholder={t.ipfs}
               value={ipfsHash}
               onChange={(e) => setIpfsHash(e.target.value)}
             />
             <input
               className="w-full border p-2 text-black"
-              placeholder="Type de contenu"
+              placeholder={t.type}
               value={contentType}
               onChange={(e) => setContentType(e.target.value)}
             />
@@ -87,19 +117,19 @@ export default function UploadDesignPage() {
                 checked={allowAI}
                 onChange={(e) => setAllowAI(e.target.checked)}
               />
-              <span>Autoriser l'entraînement IA</span>
+              <span>{t.allowAI}</span>
             </label>
             <button
               type="submit"
               className="bg-purple-600 hover:bg-purple-700 transition-colors text-white px-4 py-2 rounded"
               disabled={loading}
             >
-              {loading ? 'Enregistrement...' : 'Enregistrer le design'}
+              {loading ? t.saving : t.save}
             </button>
           </form>
         )}
         {ipId !== null && (
-          <p className="text-green-500">Design enregistré avec l'ID : {ipId}</p>
+          <p className="text-green-500">{t.saved} {ipId}</p>
         )}
         {error && <p className="text-red-500">{error}</p>}
       </div>

--- a/src/components/WalletConnectPage.tsx
+++ b/src/components/WalletConnectPage.tsx
@@ -1,15 +1,29 @@
 import React from 'react';
 import { useWeb3 } from '../contexts/Web3Context';
 import WalletConnectButton from './WalletConnectButton';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const texts = {
+  en: {
+    title: 'Wallet connection',
+    connected: 'Connected:',
+  },
+  fr: {
+    title: 'Connexion au wallet',
+    connected: 'Connecté :',
+  },
+} as const;
 
 export default function WalletConnectPage() {
   const { address } = useWeb3();
+  const { language } = useLanguage();
+  const t = texts[language];
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-2 text-white">Connexion au wallet</h1>
+      <h1 className="text-xl font-bold mb-2 text-white">{t.title}</h1>
       <WalletConnectButton />
       {address && (
-        <p className="text-white mt-2">Connecté : {address}</p>
+        <p className="text-white mt-2">{t.connected} {address}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add translation dictionaries to various pages
- switch text based on selected language
- ensure English displays properly when chosen

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850085937a48329bce24aefe26aee84