### PR TITLE
Add language specific perks in tokens

### DIFF
--- a/src/components/RoyaltyTokensPage.tsx
+++ b/src/components/RoyaltyTokensPage.tsx
@@ -171,7 +171,7 @@ export default function RoyaltyTokensPage() {
               <div>
                 <div className="font-semibold">{t.perks}</div>
                 <ul className="list-disc list-inside text-sm space-y-1">
-                  {token.perks.map(p => (
+                  {token.perks[language].map(p => (
                     <li key={p}>{p}</li>
                   ))}
                 </ul>

--- a/src/components/TokenDetailPage.tsx
+++ b/src/components/TokenDetailPage.tsx
@@ -82,7 +82,7 @@ export default function TokenDetailPage() {
               <div className="bg-white/10 backdrop-blur border border-purple-800 rounded p-4">
                 <div className="font-semibold mb-2">{t.perks}</div>
                 <ul className="space-y-1">
-                  {token.perks.map(p => (
+                  {token.perks[language].map(p => (
                     <li key={p} className="flex items-center">
                       <FaCheck className="text-green-500 mr-2" />
                       <span>{p}</span>

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -13,7 +13,10 @@ export interface SwapToken {
   ipAssetId: string;
   holders: number;
   revenueShare: number; // percent
-  perks: string[];
+  perks: {
+    en: string[];
+    fr: string[];
+  };
   listedAt: string; // ISO date
 }
 
@@ -33,7 +36,10 @@ export const tokens: SwapToken[] = [
     ipAssetId: '1',
     holders: 78,
     revenueShare: 25,
-    perks: ['Groupe privé', 'Lien d’affiliation', 'Réductions sur le merch'],
+    perks: {
+      en: ['Private group', 'Affiliate link', 'Merch discounts'],
+      fr: ['Groupe privé', 'Lien d’affiliation', 'Réductions sur le merch'],
+    },
     listedAt: '2023-10-01T00:00:00Z'
   },
   {
@@ -51,7 +57,10 @@ export const tokens: SwapToken[] = [
     ipAssetId: '2',
     holders: 42,
     revenueShare: 15,
-    perks: ['Groupe privé', 'Réductions sur le merch'],
+    perks: {
+      en: ['Private group', 'Merch discounts'],
+      fr: ['Groupe privé', 'Réductions sur le merch'],
+    },
     listedAt: '2023-10-03T00:00:00Z'
   },
   {
@@ -69,7 +78,10 @@ export const tokens: SwapToken[] = [
     ipAssetId: '3',
     holders: 55,
     revenueShare: 20,
-    perks: ['Groupe privé'],
+    perks: {
+      en: ['Private group'],
+      fr: ['Groupe privé'],
+    },
     listedAt: '2023-09-28T00:00:00Z'
   }
 ];


### PR DESCRIPTION
## Summary
- update token perks structure to store English and French versions
- show the localized perks in `RoyaltyTokensPage` and `TokenDetailPage`

## Testing
- `npm test` *(fails: You are not inside a Hardhat project)*

------
https://chatgpt.com/codex/tasks/task_e_68502c90aff88329b1eab7da5001736a