### PR TITLE
Add backend service configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,22 @@
 services:
   - type: web
-    name: mintyshirt
+    name: mintyshirt-frontend
     env: node
     buildCommand: yarn install && yarn run build
     startCommand: node server.js
     envVars:
       - key: PORT
         value: 3000
+
+  - type: web
+    name: mintyshirt-backend
+    env: python
+    buildCommand: pip install -r backend/requirements.txt
+    startCommand: python backend/src/main.py
+    envVars:
+      - key: FLASK_ENV
+        value: production
+      - key: SECRET_KEY
+        value: <secure secret>
+      - key: DATABASE_URL
+        value: <database url>


### PR DESCRIPTION
## Summary
- add Flask backend service to render.yaml

## Testing
- `npm install`
- `npm test` *(fails: `HardhatError: HH1: You are not inside a Hardhat project.`)*

------
https://chatgpt.com/codex/tasks/task_e_685c07a969cc8329a96b1bb1770b12af