### PR TITLE
Configure Flask port via environment

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -48,4 +48,5 @@ def serve(path):
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=False)


### PR DESCRIPTION
## Summary
- allow the backend to read a `PORT` env variable for the Flask server
- disable debug mode in production

## Testing
- `python3 -m py_compile backend/src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685c12a20d708329a99bc448d917cf26