### PR TITLE
Update VITE_API_URL for Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
        base sur cette variable. Si elle n'est pas renseignée, `/api` sera
        utilisé par défaut. Si le backend expose ses routes sous `/api`, cette
        valeur doit inclure ce préfixe, par exemple&nbsp;:
-       `VITE_API_URL=https://example.com/api`
+      `VITE_API_URL=https://mintyshirt.onrender.com/api`
    - `VITE_CONTRACT_REGISTRY` : Adresse du contrat MintyShirtRegistry
    - `VITE_CONTRACT_LICENSE` : Adresse du contrat LicenseManager
    - `VITE_CONTRACT_REVENUE` : Adresse du contrat RevenueDistributor

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 
 [context.production.environment]
   NODE_VERSION = "16"
-  VITE_API_URL = "https://mintyshirt-backend.onrender.com/api"
+  VITE_API_URL = "https://mintyshirt.onrender.com/api"
   VITE_CONTRACT_REGISTRY = "0x7C3149C56527Af298C4393a1D3A27E715E5B174B"
   VITE_CONTRACT_LICENSE = "0x9D7f74d0C41E726EC95884E0e97Fa6129e3b5E99"
   VITE_CONTRACT_REVENUE = "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"


### PR DESCRIPTION
## Summary
- update `netlify.toml` with new Render domain
- adjust `README` example to match the new API domain

## Testing
- `npm test` *(fails: Error HH1: You are not inside a Hardhat project)*

------
https://chatgpt.com/codex/tasks/task_e_685c13ac3d50832992a8c812fc65e6b1