### PR TITLE
Fix test script compile step

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "build": "vite build",
     "dev": "vite",
-    "test": "hardhat compile && jest"
+    "test": "cd smart-contracts && npx hardhat compile && cd .. && jest"
   },
   "dependencies": {
     "axios": "^1.3.5",


### PR DESCRIPTION
## Summary
- run Hardhat from smart-contracts directory before Jest tests

## Testing
- `npm install`
- `npm test` *(fails to download Solidity compiler due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c146709c48329bbf0205624960d8b