### PR TITLE
Configure Vite proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Le projet MintyShirt est une plateforme décentralisée pour les créateurs de d
    - Regroupement de transactions pour réduire les coûts de gaz
    - Utilisation de multicall ou contrats agrégateurs
 
+## Développement Local
+
+Le frontend utilise Vite. Le fichier `vite.config.ts` configure un proxy pour
+rediriger les requêtes vers `/api` vers le backend local sur
+`http://localhost:5000`. Cette règle permet de conserver le même chemin d'API
+entre l'environnement de développement et la production.
+
 ## Instructions pour le Déploiement
 
 ### GitHub

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
+  },
   build: {
     outDir: 'dist'
   }


### PR DESCRIPTION
## Summary
- add proxy configuration in `vite.config.ts` so `/api` calls go to the backend
- describe the new proxy behaviour in a new "Développement Local" section in README

## Testing
- `npm test` *(fails: couldn't download compiler due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6864d85c139883299146438c60cdb6fd