### PR TITLE
Add API 404 handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,6 +6,9 @@ const PORT = process.env.PORT || 3000;
 // Servir les fichiers statiques du dossier dist
 app.use(express.static(path.join(__dirname, 'dist')));
 
+// Return 404 for API routes so SPA HTML isn't served for missing endpoints
+app.use('/api', (_, res) => res.status(404).end());
+
 // Toutes les requêtes non traitées par les routes précédentes seront redirigées vers index.html
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'));


### PR DESCRIPTION
## Summary
- add `/api` route to return 404 before catch-all handler

## Testing
- `npm install --no-audit --progress=false`
- `npm test --yes` *(fails: couldn't download Solidity compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6864df8bcb3c8329a5d4680b45768221